### PR TITLE
libkrun: add config_size to KipConfig

### DIFF
--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -27,6 +27,8 @@ int main(int argc, void **argv)
 
     memset(&config, 0,  sizeof(config));
 
+    // Set the size of the config struct known at build time.
+    config.config_size = sizeof(config);
     // Set the krun's verbosity to the minimum.
     config.log_level = 0;
     // Request a single vCPU.

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -1,6 +1,8 @@
 #include <inttypes.h>
 
 struct krun_config {
+    /* Size of the krun_config struct. */
+    size_t config_size;
     /* Verbosity of the library, from 0=Off to 5=Trace. */
     uint8_t log_level;
     /* Number of vCPUs for the VM. */


### PR DESCRIPTION
let the libkrun user specify the size of the "struct krun_config" to
help detecting mismatches between the configuration used by the user
of the library and what libkrun handles.

If the specified size is bigger than what libkrun uses, then it means
there are extra options specified by the user that libkrun cannot
honor.

We could handle the case where the specified size is less than what
libkrun knows and don't handle what is not known to the library user
but simplify usage for now and error out in both cases.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>