### PR TITLE
vmm,devices: VM snapshot/restore (HVF)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ examples/rootfs_fedora
 test-prefix
 /linux-sysroot
 /freebsd-sysroot
+
+# stray rustc playground artifact
+*.rlib

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ examples/boot_efi
 examples/external_kernel
 examples/nitro
 examples/consoles
+examples/snapshot
+*.dSYM/
 examples/rootfs_fedora
 test-prefix
 /linux-sysroot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
  "bincode_derive",
+ "serde",
  "unty",
 ]
 
@@ -662,6 +663,7 @@ dependencies = [
 name = "krun-devices"
 version = "0.1.0-2.0.0-dev"
 dependencies = [
+ "bincode",
  "bitflags 1.3.2",
  "caps",
  "crossbeam-channel",
@@ -798,6 +800,7 @@ dependencies = [
 name = "krun-vmm"
 version = "0.1.0-2.0.0-dev"
 dependencies = [
+ "bincode",
  "bitfield",
  "bitflags 2.11.0",
  "bzip2",

--- a/README.md
+++ b/README.md
@@ -70,7 +70,58 @@ Each variant generates a dynamic library with a different name (and ```soname```
 Capture a running VM (vCPU, interrupt controller, devices, and memory) to a
 directory with `krun_snapshot_request()`, then restore it onto a
 freshly-configured context and resume from the captured point with
-`krun_restore()`. See `include/libkrun.h` for the full API.
+`krun_restore()`. See `include/libkrun.h` for the full API, and
+`examples/snapshot.c` for a working capture/restore pair.
+
+```c
+/* Capture: from a thread other than the one in krun_start_enter(). */
+krun_snapshot_request(ctx, "/path/to/snapshot", KRUN_SNAPSHOT_EXIT);
+
+/* Restore: configure an identical VM, then resume it instead of booting. */
+krun_restore(ctx, "/path/to/snapshot", 0);
+```
+
+The snapshot is a directory holding `manifest.json`, `vmstate` and `memory.img`.
+It is FD-free: only transport and queue state is serialized, never host file
+descriptors. Restore is config-validate — you rebuild the same VM with fresh
+fds, and `krun_restore()` checks it against the manifest (arch, memory, vCPU
+count, and the ordered device topology) before hydrating state onto it. A
+mismatch is rejected rather than silently mis-bound.
+
+Snapshot the guest at a steady state. Capturing mid-boot leaves device state
+that cannot be cleanly restored.
+
+### Limitations
+
+- **macOS/HVF, aarch64 only.** The KVM vCPU and GIC paths are stubs.
+- **Single vCPU.** Restoring a snapshot with more is rejected: the GIC blob must
+  be written once after every redistributor exists, and all vCPUs must share one
+  vtimer offset.
+- **No nested virtualization.** EL2 registers are not captured, so restoring a
+  nested VM is rejected.
+- **Device worker threads are not stopped at capture.** Freezing the vCPUs stops
+  the guest, but a device's workers keep running, so their queue indices are
+  reconstructed rather than read. This holds for an idle guest, which is why the
+  snapshot must be taken at a steady state; a capture taken under active device
+  I/O can restore inconsistently.
+- **Per-device internal state is not captured** beyond the virtio queues. A
+  device holding host-side state across a snapshot (in-flight block requests,
+  vsock connections, virtio-fs open fids) will not have it restored.
+- **`KRUN_SNAPSHOT_RESUME` is not implemented**; capture always exits the
+  process (`KRUN_SNAPSHOT_EXIT`).
+- Restore copies `memory.img` into guest RAM, so RSS is the full VM size.
+
+### Planned
+
+- Quiescing the devices at capture, so their workers stop and hand back the live
+  queues instead of the indices being reconstructed. That is what makes a
+  snapshot under active I/O sound.
+- Multi-vCPU restore (a GIC barrier across the vCPU threads, one shared vtimer
+  offset).
+- Per-device internal state, and serializing a partially consumed descriptor.
+- Capture-and-continue (`KRUN_SNAPSHOT_RESUME`).
+- `MAP_PRIVATE` of `memory.img` so a restored VM demand-pages instead of copying,
+  which is also what makes cloning many VMs from one snapshot cheap.
 
 
 ## Networking

--- a/README.md
+++ b/README.md
@@ -99,23 +99,23 @@ that cannot be cleanly restored.
   vtimer offset.
 - **No nested virtualization.** EL2 registers are not captured, so restoring a
   nested VM is rejected.
-- **Device worker threads are not stopped at capture.** Freezing the vCPUs stops
-  the guest, but a device's workers keep running, so their queue indices are
-  reconstructed rather than read. This holds for an idle guest, which is why the
-  snapshot must be taken at a steady state; a capture taken under active device
-  I/O can restore inconsistently.
-- **Per-device internal state is not captured** beyond the virtio queues. A
-  device holding host-side state across a snapshot (in-flight block requests,
-  vsock connections, virtio-fs open fids) will not have it restored.
+- **Devices**: block, virtio-fs, console, rng and balloon can be snapshotted.
+  The rest (net, vsock, gpu, input) cannot be quiesced yet and refuse the
+  snapshot rather than being captured mid-flight.
+- **Per-device internal state is not captured** beyond the virtio queues and the
+  console's open ports. A device holding host-side state across a snapshot
+  (in-flight block requests, vsock connections, virtio-fs open fids) will not
+  have it restored.
+- **A partially consumed descriptor is not serialized.** Devices are quiesced at
+  a descriptor boundary, so a request the guest had submitted but the device had
+  not finished is not preserved.
 - **`KRUN_SNAPSHOT_RESUME` is not implemented**; capture always exits the
   process (`KRUN_SNAPSHOT_EXIT`).
 - Restore copies `memory.img` into guest RAM, so RSS is the full VM size.
 
 ### Planned
 
-- Quiescing the devices at capture, so their workers stop and hand back the live
-  queues instead of the indices being reconstructed. That is what makes a
-  snapshot under active I/O sound.
+- Quiesce support for the remaining devices (net, vsock, gpu, input).
 - Multi-vCPU restore (a GIC barrier across the vCPU threads, one shared vtimer
   offset).
 - Per-device internal state, and serializing a partially consumed descriptor.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Each variant generates a dynamic library with a different name (and ```soname```
 * virtio-rng
 
 
+## Snapshot and restore (experimental)
+
+> Available on the macOS/HVF backend only, and part of the still-evolving 2.0 API.
+
+Capture a running VM (vCPU, interrupt controller, devices, and memory) to a
+directory with `krun_snapshot_request()`, then restore it onto a
+freshly-configured context and resume from the captured point with
+`krun_restore()`. See `include/libkrun.h` for the full API.
+
+
 ## Networking
 
 In ```libkrun```, networking is provided by two different, mutually exclusive techniques: **virtio-vsock + TSI** and **virtio-net + passt/gvproxy**.

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -13,7 +13,7 @@ ROOTFS_DIR = rootfs_$(ROOTFS_DISTRO)
 
 .PHONY: clean rootfs
 
-EXAMPLES := boot_efi chroot_vm external_kernel consoles
+EXAMPLES := boot_efi chroot_vm external_kernel consoles snapshot
 ifeq ($(SEV),1)
     EXAMPLES := launch-tee
 endif
@@ -51,6 +51,12 @@ endif
 
 consoles: consoles.c
 	gcc -o $@ $< $(CFLAGS) $(LDFLAGS_$(ARCH)_$(OS))
+
+snapshot: snapshot.c
+	gcc -o $@ $< $(CFLAGS) $(LDFLAGS_$(ARCH)_$(OS))
+ifeq ($(OS),Darwin)
+	codesign --entitlements chroot_vm.entitlements --force -s - $@
+endif
 
 nitro: nitro.c
 	gcc -o $@ $< $(CFLAGS) $(LDFLAGS_nitro)

--- a/examples/snapshot.c
+++ b/examples/snapshot.c
@@ -1,0 +1,175 @@
+/*
+ * Snapshot a running VM to a directory, then restore it and carry on.
+ *
+ * Usage:
+ *   ./snapshot capture <snapshot_dir> <rootfs_dir>
+ *   ./snapshot restore <snapshot_dir> <rootfs_dir>
+ *
+ * "capture" boots the guest, waits for it to settle, then asks libkrun to
+ * serialize it and exit. "restore" builds a VM with the *same* configuration and
+ * resumes the guest from where it was captured -- it picks up mid-command, so the
+ * counter it prints continues rather than starting over.
+ *
+ * macOS/HVF only. Currently 1 vCPU (see "Limitations" in the README).
+ */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libkrun.h>
+
+#define VCPUS      1
+#define RAM_MIB    512
+
+/*
+ * Capture and restore must describe the same machine: krun_restore() validates
+ * the fresh config against the snapshot manifest and refuses a mismatch. Build
+ * both from one function to guarantee that.
+ */
+static int configure_vm(uint32_t ctx, const char *rootfs)
+{
+    int err;
+
+    if ((err = krun_set_vm_config(ctx, VCPUS, RAM_MIB)) < 0) {
+        errno = -err;
+        perror("krun_set_vm_config");
+        return -1;
+    }
+
+    if ((err = krun_add_virtio_console_default(ctx, STDIN_FILENO, STDOUT_FILENO,
+                                               STDERR_FILENO)) < 0) {
+        errno = -err;
+        perror("krun_add_virtio_console_default");
+        return -1;
+    }
+
+    if ((err = krun_add_virtiofs3(ctx, "/dev/root", rootfs, 0, false)) < 0) {
+        errno = -err;
+        perror("krun_add_virtiofs3");
+        return -1;
+    }
+
+    if ((err = krun_set_workdir(ctx, "/")) < 0) {
+        errno = -err;
+        perror("krun_set_workdir");
+        return -1;
+    }
+
+    /* Print a counter forever, so a restored guest visibly resumes mid-count. */
+    const char *argv[] = { "-c", "i=0; while :; do echo tick $i; i=$((i+1)); sleep 1; done", NULL };
+    const char *envp[] = { NULL };
+    if ((err = krun_set_exec(ctx, "/bin/sh", argv, envp)) < 0) {
+        errno = -err;
+        perror("krun_set_exec");
+        return -1;
+    }
+
+    return 0;
+}
+
+struct trigger_args {
+    uint32_t ctx;
+    const char *dir;
+};
+
+/*
+ * Out-of-band: must run on a thread other than the one in krun_start_enter().
+ * The control channel isn't registered until the event loop is up, so retry past
+ * the initial -ENOENT. Snapshot at a steady state (mid-boot won't restore).
+ *
+ * Args are heap-allocated (not on capture()'s stack): the success path never
+ * returns here, but an error path can, while this thread still runs.
+ */
+static void *trigger_snapshot(void *arg)
+{
+    struct trigger_args *args = arg;
+    int err;
+
+    sleep(5);
+
+    while ((err = krun_snapshot_request(args->ctx, args->dir, KRUN_SNAPSHOT_EXIT)) == -ENOENT)
+        usleep(100000);
+
+    if (err < 0) {
+        errno = -err;
+        perror("krun_snapshot_request");
+    }
+    free(args);
+    return NULL;
+}
+
+static int capture(const char *dir, const char *rootfs)
+{
+    pthread_t thread;
+    int32_t ctx = krun_create_ctx();
+    if (ctx < 0) {
+        errno = -ctx;
+        perror("krun_create_ctx");
+        return -1;
+    }
+
+    if (configure_vm(ctx, rootfs) < 0)
+        return -1;
+
+    struct trigger_args *args = malloc(sizeof(*args));
+    if (!args) {
+        perror("malloc");
+        return -1;
+    }
+    args->ctx = ctx;
+    args->dir = dir;
+
+    if (pthread_create(&thread, NULL, trigger_snapshot, args) != 0) {
+        perror("pthread_create");
+        free(args);
+        return -1;
+    }
+    pthread_detach(thread);
+
+    /* Blocks: the thread above triggers the snapshot, which writes the files and
+     * exits the process. Does not return. */
+    int err = krun_start_enter(ctx);
+    errno = -err;
+    perror("krun_start_enter");
+    return -1;
+}
+
+static int restore(const char *dir, const char *rootfs)
+{
+    int32_t ctx = krun_create_ctx();
+    if (ctx < 0) {
+        errno = -ctx;
+        perror("krun_create_ctx");
+        return -1;
+    }
+
+    /* Same machine as the one we captured, with fresh host fds. */
+    if (configure_vm(ctx, rootfs) < 0)
+        return -1;
+
+    /* Blocks like krun_start_enter(), but the guest resumes instead of booting. */
+    int err = krun_restore(ctx, dir, 0);
+    errno = -err;
+    perror("krun_restore");
+    return -1;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 4) {
+        fprintf(stderr, "usage: %s capture|restore <snapshot_dir> <rootfs_dir>\n", argv[0]);
+        return 1;
+    }
+
+    if (!strcmp(argv[1], "capture"))
+        return capture(argv[2], argv[3]) < 0 ? 1 : 0;
+    if (!strcmp(argv[1], "restore"))
+        return restore(argv[2], argv[3]) < 0 ? 1 : 0;
+
+    fprintf(stderr, "unknown command: %s\n", argv[1]);
+    return 1;
+}

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -1365,6 +1365,32 @@ int32_t krun_vm_resume(uint32_t ctx_id);
 int32_t krun_snapshot_request(uint32_t ctx_id, const char *snapshot_path,
                               uint32_t flags);
 
+/**
+ * Restore a VM from a snapshot and run it. "ctx_id" must be an already-
+ * configured context whose shape (architecture, memory size, vCPU count)
+ * matches the snapshot's "manifest.json"; krun_restore() validates that, then
+ * hydrates guest RAM, device, and vCPU state onto it and enters the guest.
+ * Currently macOS/HVF only; returns -ENOTSUP elsewhere and on TEE builds.
+ *
+ * Devices are reconfigured fresh by the caller (with new host fds); the saved
+ * transport state binds onto them, so open file descriptors need not survive.
+ *
+ * Arguments:
+ *  "ctx_id"        - the configuration context ID.
+ *  "snapshot_path" - the snapshot directory written by krun_snapshot_request().
+ *  "flags"         - reserved, must be 0.
+ *
+ * Notes:
+ *  Like krun_start_enter(), on success this assumes control of the process and
+ *  does not return until the restored guest exits.
+ *
+ * Returns:
+ *  -EINVAL  - bad path, non-zero flags, or a config that doesn't match the
+ *             snapshot manifest.
+ *  -ENOTSUP - restore is unsupported on this platform/build.
+ */
+int32_t krun_restore(uint32_t ctx_id, const char *snapshot_path, uint32_t flags);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -1336,6 +1336,35 @@ int32_t krun_vm_pause(uint32_t ctx_id);
  */
 int32_t krun_vm_resume(uint32_t ctx_id);
 
+/* Snapshot flags. */
+#define KRUN_SNAPSHOT_EXIT 0   /* capture, then exit */
+#define KRUN_SNAPSHOT_RESUME 1 /* capture, then resume (unimplemented) */
+
+/**
+ * Thread-safe, out-of-band snapshot trigger for a VM already running under
+ * krun_start_enter() on another thread. The VM's event loop freezes the vCPUs,
+ * serializes the VM into "snapshot_path", and exits the process.
+ *
+ * The snapshot is written as a directory containing "manifest.json", "vmstate",
+ * and "memory.img".
+ *
+ * Currently macOS/HVF only; returns -ENOTSUP elsewhere and on TEE builds.
+ *
+ * Arguments:
+ *  "ctx_id"        - the configuration context ID of the running VM.
+ *  "snapshot_path" - destination directory for the snapshot.
+ *  "flags"         - KRUN_SNAPSHOT_EXIT.
+ *
+ * Returns:
+ *  0        - the snapshot request was signalled.
+ *  -EINVAL  - bad path or unsupported flags.
+ *  -ENOENT  - no running VM is registered for this ctx_id.
+ *  -EIO     - failed to signal the VM.
+ *  -ENOTSUP - snapshots are unsupported on this platform/build.
+ */
+int32_t krun_snapshot_request(uint32_t ctx_id, const char *snapshot_path,
+                              uint32_t flags);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -23,6 +23,7 @@ timesync = []
 vhost-user = ["vhost", "vmm-sys-util"]
 
 [dependencies]
+bincode = { version = "2.0.1", default-features = false, features = ["std", "derive"] }
 bitflags = "1.2.0"
 crossbeam-channel = ">=0.5.15"
 libc = ">=0.2.39"

--- a/src/devices/src/legacy/hvfgicv3.rs
+++ b/src/devices/src/legacy/hvfgicv3.rs
@@ -9,12 +9,36 @@ use crate::bus::BusDevice;
 use crate::legacy::gic::GICDevice;
 use crate::legacy::irqchip::IrqChipT;
 
+use std::os::raw::c_void;
+
 use hvf::Error;
-use hvf::bindings::{HV_SUCCESS, hv_gic_config_t, hv_ipa_t, hv_return_t};
+use hvf::bindings::{
+    HV_SUCCESS, hv_gic_config_t, hv_gic_icc_reg_t, hv_gic_icc_reg_t_HV_GIC_ICC_REG_AP0R0_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_AP1R0_EL1, hv_gic_icc_reg_t_HV_GIC_ICC_REG_BPR0_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_BPR1_EL1, hv_gic_icc_reg_t_HV_GIC_ICC_REG_CTLR_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_IGRPEN0_EL1, hv_gic_icc_reg_t_HV_GIC_ICC_REG_IGRPEN1_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_PMR_EL1, hv_gic_icc_reg_t_HV_GIC_ICC_REG_SRE_EL1,
+    hv_gic_state_t, hv_ipa_t, hv_return_t, hv_vcpu_t, os_release,
+};
 use utils::eventfd::EventFd;
 
 // Device trees specific constants
 const ARCH_GIC_V3_MAINT_IRQ: u32 = 9;
+
+/// Per-vCPU GIC CPU-interface (ICC) registers captured for snapshot. These are
+/// the writable interface controls (group enables, priority mask, binary point,
+/// active-priority); RPR is read-only and the nested EL2 SRE is excluded.
+const SAVED_ICC: &[hv_gic_icc_reg_t] = &[
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_SRE_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_CTLR_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_PMR_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_BPR0_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_BPR1_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_IGRPEN0_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_IGRPEN1_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_AP0R0_EL1,
+    hv_gic_icc_reg_t_HV_GIC_ICC_REG_AP1R0_EL1,
+];
 
 pub struct HvfGicBindings {
     hv_gic_create:
@@ -29,6 +53,20 @@ pub struct HvfGicBindings {
     hv_gic_get_redistributor_size:
         libloading::Symbol<'static, unsafe extern "C" fn(*mut usize) -> hv_return_t>,
     hv_gic_set_spi: libloading::Symbol<'static, unsafe extern "C" fn(u32, bool) -> hv_return_t>,
+    // Snapshot save-side symbols (restore-side lands with M2).
+    hv_gic_state_create: libloading::Symbol<'static, unsafe extern "C" fn() -> hv_gic_state_t>,
+    hv_gic_state_get_size: libloading::Symbol<
+        'static,
+        unsafe extern "C" fn(hv_gic_state_t, *mut usize) -> hv_return_t,
+    >,
+    hv_gic_state_get_data: libloading::Symbol<
+        'static,
+        unsafe extern "C" fn(hv_gic_state_t, *mut c_void) -> hv_return_t,
+    >,
+    hv_gic_get_icc_reg: libloading::Symbol<
+        'static,
+        unsafe extern "C" fn(hv_vcpu_t, hv_gic_icc_reg_t, *mut u64) -> hv_return_t,
+    >,
 }
 
 pub struct HvfGicV3 {
@@ -69,6 +107,14 @@ impl HvfGicV3 {
                     .get(b"hv_gic_get_redistributor_size")
                     .map_err(Error::FindSymbol)?,
                 hv_gic_set_spi: HVF.get(b"hv_gic_set_spi").map_err(Error::FindSymbol)?,
+                hv_gic_state_create: HVF.get(b"hv_gic_state_create").map_err(Error::FindSymbol)?,
+                hv_gic_state_get_size: HVF
+                    .get(b"hv_gic_state_get_size")
+                    .map_err(Error::FindSymbol)?,
+                hv_gic_state_get_data: HVF
+                    .get(b"hv_gic_state_get_data")
+                    .map_err(Error::FindSymbol)?,
+                hv_gic_get_icc_reg: HVF.get(b"hv_gic_get_icc_reg").map_err(Error::FindSymbol)?,
             }
         };
 
@@ -147,6 +193,49 @@ impl IrqChipT for HvfGicV3 {
                 "IRQ not line configured",
             )))
         }
+    }
+
+    fn save_gic_state(&self) -> Result<Vec<u8>, DeviceError> {
+        // Mirrors ignition's gic.rs: create state, query size, copy out,
+        // os_release on every path. The state object is the only thing freed
+        // here; os_release is a libSystem symbol, always present.
+        let gic_err = || DeviceError::Snapshot("hv_gic_state save failed".into());
+        unsafe {
+            let state = (self.bindings.hv_gic_state_create)();
+            if state.is_null() {
+                return Err(gic_err());
+            }
+            let result = (|| {
+                let mut size: usize = 0;
+                if (self.bindings.hv_gic_state_get_size)(state, &mut size) != HV_SUCCESS {
+                    return Err(gic_err());
+                }
+                let mut buf = vec![0u8; size];
+                if (self.bindings.hv_gic_state_get_data)(state, buf.as_mut_ptr() as *mut c_void)
+                    != HV_SUCCESS
+                {
+                    return Err(gic_err());
+                }
+                Ok(buf)
+            })();
+            os_release(state as *mut c_void);
+            result
+        }
+    }
+
+    fn save_vcpu_icc(&self, vcpuid: u64) -> Result<Vec<(u32, u64)>, DeviceError> {
+        SAVED_ICC
+            .iter()
+            .map(|&reg| {
+                let mut val: u64 = 0;
+                let ret = unsafe { (self.bindings.hv_gic_get_icc_reg)(vcpuid, reg, &mut val) };
+                if ret != HV_SUCCESS {
+                    Err(DeviceError::Snapshot("hv_gic_get_icc_reg failed".into()))
+                } else {
+                    Ok((reg as u32, val))
+                }
+            })
+            .collect()
     }
 }
 

--- a/src/devices/src/legacy/hvfgicv3.rs
+++ b/src/devices/src/legacy/hvfgicv3.rs
@@ -53,7 +53,7 @@ pub struct HvfGicBindings {
     hv_gic_get_redistributor_size:
         libloading::Symbol<'static, unsafe extern "C" fn(*mut usize) -> hv_return_t>,
     hv_gic_set_spi: libloading::Symbol<'static, unsafe extern "C" fn(u32, bool) -> hv_return_t>,
-    // Snapshot save-side symbols (restore-side lands with M2).
+    // Snapshot symbols (dynamic: not in the older Hypervisor.framework SDK).
     hv_gic_state_create: libloading::Symbol<'static, unsafe extern "C" fn() -> hv_gic_state_t>,
     hv_gic_state_get_size: libloading::Symbol<
         'static,
@@ -66,6 +66,12 @@ pub struct HvfGicBindings {
     hv_gic_get_icc_reg: libloading::Symbol<
         'static,
         unsafe extern "C" fn(hv_vcpu_t, hv_gic_icc_reg_t, *mut u64) -> hv_return_t,
+    >,
+    hv_gic_set_state:
+        libloading::Symbol<'static, unsafe extern "C" fn(*const c_void, usize) -> hv_return_t>,
+    hv_gic_set_icc_reg: libloading::Symbol<
+        'static,
+        unsafe extern "C" fn(hv_vcpu_t, hv_gic_icc_reg_t, u64) -> hv_return_t,
     >,
 }
 
@@ -115,6 +121,8 @@ impl HvfGicV3 {
                     .get(b"hv_gic_state_get_data")
                     .map_err(Error::FindSymbol)?,
                 hv_gic_get_icc_reg: HVF.get(b"hv_gic_get_icc_reg").map_err(Error::FindSymbol)?,
+                hv_gic_set_state: HVF.get(b"hv_gic_set_state").map_err(Error::FindSymbol)?,
+                hv_gic_set_icc_reg: HVF.get(b"hv_gic_set_icc_reg").map_err(Error::FindSymbol)?,
             }
         };
 
@@ -236,6 +244,38 @@ impl IrqChipT for HvfGicV3 {
                 }
             })
             .collect()
+    }
+
+    /// Restore the distributor/redistributor blob from [`HvfGicV3::save_gic_state`]
+    /// into the already-created in-kernel GIC. Must run after every vCPU exists:
+    /// the per-cpu redistributor state (incl. the PPI enable that gates the
+    /// virtual-timer IRQ) is dropped silently if a redistributor is missing.
+    fn restore_gic_state(&self, blob: &[u8]) -> Result<(), DeviceError> {
+        let ret =
+            unsafe { (self.bindings.hv_gic_set_state)(blob.as_ptr() as *const c_void, blob.len()) };
+        if ret != HV_SUCCESS {
+            Err(DeviceError::Snapshot("hv_gic_set_state failed".into()))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn restore_vcpu_icc(&self, vcpuid: u64, regs: &[(u32, u64)]) -> Result<(), DeviceError> {
+        for &(reg, val) in regs {
+            // Snapshot data is untrusted: only restore ICC registers we capture,
+            // so a malformed snapshot can't write an arbitrary GIC register.
+            if !SAVED_ICC.iter().any(|&r| r as u32 == reg) {
+                return Err(DeviceError::Snapshot(format!(
+                    "snapshot has unknown ICC reg id 0x{reg:x}"
+                )));
+            }
+            let ret =
+                unsafe { (self.bindings.hv_gic_set_icc_reg)(vcpuid, reg as hv_gic_icc_reg_t, val) };
+            if ret != HV_SUCCESS {
+                return Err(DeviceError::Snapshot("hv_gic_set_icc_reg failed".into()));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/devices/src/legacy/irqchip.rs
+++ b/src/devices/src/legacy/irqchip.rs
@@ -35,6 +35,18 @@ impl IrqChipDevice {
     ) -> Result<(), DeviceError> {
         self.inner.set_irq(irq_line, interrupt_evt)
     }
+
+    /// Capture the in-kernel GIC distributor/redistributor state (snapshot).
+    #[cfg(target_arch = "aarch64")]
+    pub fn save_gic_state(&self) -> Result<Vec<u8>, DeviceError> {
+        self.inner.save_gic_state()
+    }
+
+    /// Capture one vCPU's GIC CPU-interface (ICC) registers (snapshot).
+    #[cfg(target_arch = "aarch64")]
+    pub fn save_vcpu_icc(&self, vcpuid: u64) -> Result<Vec<(u32, u64)>, DeviceError> {
+        self.inner.save_vcpu_icc(vcpuid)
+    }
 }
 
 impl BusDevice for IrqChipDevice {
@@ -132,6 +144,23 @@ pub trait IrqChipT: BusDevice + GICDevice {
         irq_line: Option<u32>,
         interrupt_evt: Option<&EventFd>,
     ) -> Result<(), DeviceError>;
+
+    /// Capture the in-kernel GIC distributor/redistributor state as an opaque
+    /// blob (snapshot). Default: unsupported — only the HVF GIC overrides it.
+    fn save_gic_state(&self) -> Result<Vec<u8>, DeviceError> {
+        Err(DeviceError::Snapshot(
+            "GIC state snapshot not supported by this irqchip".into(),
+        ))
+    }
+
+    /// Capture one vCPU's GIC CPU-interface (ICC) registers (snapshot). These
+    /// live in the vCPU interface, not the global blob above. Default:
+    /// unsupported.
+    fn save_vcpu_icc(&self, _vcpuid: u64) -> Result<Vec<(u32, u64)>, DeviceError> {
+        Err(DeviceError::Snapshot(
+            "vCPU ICC snapshot not supported by this irqchip".into(),
+        ))
+    }
 }
 
 #[cfg(target_arch = "riscv64")]

--- a/src/devices/src/legacy/irqchip.rs
+++ b/src/devices/src/legacy/irqchip.rs
@@ -47,6 +47,18 @@ impl IrqChipDevice {
     pub fn save_vcpu_icc(&self, vcpuid: u64) -> Result<Vec<(u32, u64)>, DeviceError> {
         self.inner.save_vcpu_icc(vcpuid)
     }
+
+    /// Restore the in-kernel GIC distributor/redistributor state (restore).
+    #[cfg(target_arch = "aarch64")]
+    pub fn restore_gic_state(&self, blob: &[u8]) -> Result<(), DeviceError> {
+        self.inner.restore_gic_state(blob)
+    }
+
+    /// Restore one vCPU's GIC CPU-interface (ICC) registers (restore).
+    #[cfg(target_arch = "aarch64")]
+    pub fn restore_vcpu_icc(&self, vcpuid: u64, regs: &[(u32, u64)]) -> Result<(), DeviceError> {
+        self.inner.restore_vcpu_icc(vcpuid, regs)
+    }
 }
 
 impl BusDevice for IrqChipDevice {
@@ -159,6 +171,22 @@ pub trait IrqChipT: BusDevice + GICDevice {
     fn save_vcpu_icc(&self, _vcpuid: u64) -> Result<Vec<(u32, u64)>, DeviceError> {
         Err(DeviceError::Snapshot(
             "vCPU ICC snapshot not supported by this irqchip".into(),
+        ))
+    }
+
+    /// Restore the GIC distributor/redistributor blob (restore). Default:
+    /// unsupported — only the HVF GIC overrides it.
+    fn restore_gic_state(&self, _blob: &[u8]) -> Result<(), DeviceError> {
+        Err(DeviceError::Snapshot(
+            "GIC state restore not supported by this irqchip".into(),
+        ))
+    }
+
+    /// Restore one vCPU's GIC CPU-interface (ICC) registers (restore). Default:
+    /// unsupported.
+    fn restore_vcpu_icc(&self, _vcpuid: u64, _regs: &[(u32, u64)]) -> Result<(), DeviceError> {
+        Err(DeviceError::Snapshot(
+            "vCPU ICC restore not supported by this irqchip".into(),
         ))
     }
 }

--- a/src/devices/src/legacy/rtc_pl031.rs
+++ b/src/devices/src/legacy/rtc_pl031.rs
@@ -8,11 +8,13 @@
 //! a real-time clock input.
 //!
 
+use bincode::{Decode, Encode};
 use std::fmt;
 use std::time::Instant;
 use std::{io, result};
 
 use crate::BusDevice;
+use crate::snapshot::{DeviceState, Snapshottable};
 use utils::byte_order;
 use utils::eventfd::EventFd;
 //use bus::Error;
@@ -180,6 +182,62 @@ impl BusDevice for RTC {
     }
 }
 
+/// Version of the RTC snapshot encoding.
+const RTC_SNAPSHOT_VERSION: u8 = 2;
+
+/// Resume-critical RTC state. `now_ns` is the absolute tick value so restore can
+/// re-anchor against a fresh `Instant::now()`.
+#[derive(Encode, Decode)]
+struct RtcState {
+    now_ns: i64,
+    match_value: u32,
+    load: u32,
+    imsc: u32,
+    ris: u32,
+}
+
+impl Snapshottable for RTC {
+    fn id(&self) -> &str {
+        "rtc"
+    }
+
+    fn save(&self) -> std::result::Result<DeviceState, crate::Error> {
+        let state = RtcState {
+            now_ns: self.tick_offset
+                + Instant::now().duration_since(self.previous_now).as_nanos() as i64,
+            match_value: self.match_value,
+            load: self.load,
+            imsc: self.imsc,
+            ris: self.ris,
+        };
+        let bytes = bincode::encode_to_vec(&state, bincode::config::standard())
+            .map_err(|e| crate::Error::Snapshot(e.to_string()))?;
+        Ok(DeviceState {
+            version: RTC_SNAPSHOT_VERSION,
+            bytes,
+        })
+    }
+
+    fn restore(&mut self, state: &DeviceState) -> std::result::Result<(), crate::Error> {
+        if state.version != RTC_SNAPSHOT_VERSION {
+            return Err(crate::Error::Snapshot(format!(
+                "rtc: unsupported state version {}",
+                state.version
+            )));
+        }
+        let (s, _): (RtcState, _) =
+            bincode::decode_from_slice(&state.bytes, bincode::config::standard())
+                .map_err(|e| crate::Error::Snapshot(format!("rtc: {e}")))?;
+        self.tick_offset = s.now_ns;
+        self.previous_now = Instant::now();
+        self.match_value = s.match_value;
+        self.load = s.load;
+        self.imsc = s.imsc;
+        self.ris = s.ris;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -237,5 +295,46 @@ mod tests {
         rtc.read(0, AMBA_ID_LOW, &mut data);
         let index = AMBA_ID_LOW + 3;
         assert_eq!(data[0], PL031_ID[((index - AMBA_ID_LOW) >> 2) as usize]);
+    }
+
+    #[test]
+    fn test_rtc_snapshot_round_trip() {
+        let mut rtc = RTC::new(EventFd::new(utils::eventfd::EFD_NONBLOCK).unwrap());
+        let mut data = [0; 4];
+        byte_order::write_le_u32(&mut data, 42);
+        rtc.write(0, RTCMR, &data); // match_value = 42
+        byte_order::write_le_u32(&mut data, 1);
+        rtc.write(0, RTCIMSC, &data); // imsc = 1
+        let _ = rtc.interrupt_evt.read();
+
+        let state = rtc.save().unwrap();
+
+        let mut restored = RTC::new(EventFd::new(utils::eventfd::EFD_NONBLOCK).unwrap());
+        restored.restore(&state).unwrap();
+        assert_eq!(restored.match_value, 42);
+        assert_eq!(restored.imsc, 1);
+        // The captured absolute tick is re-anchored, so the clock reads back
+        // within a second of the original.
+        assert!(restored.get_time().abs_diff(rtc.get_time()) <= 1);
+
+        // A truncated or wrong-version blob is rejected, not half-applied.
+        let mut bad = state.bytes.clone();
+        bad.truncate(10);
+        assert!(
+            restored
+                .restore(&DeviceState {
+                    version: RTC_SNAPSHOT_VERSION,
+                    bytes: bad,
+                })
+                .is_err()
+        );
+        assert!(
+            restored
+                .restore(&DeviceState {
+                    version: RTC_SNAPSHOT_VERSION + 1,
+                    bytes: state.bytes.clone(),
+                })
+                .is_err()
+        );
     }
 }

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -17,9 +17,11 @@ mod bus;
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 pub mod fdt;
 pub mod legacy;
+pub mod snapshot;
 pub mod virtio;
 
 pub use self::bus::{Bus, BusDevice, Error as BusError};
+pub use self::snapshot::{DeviceState, Snapshottable};
 
 #[derive(Debug)]
 pub enum Error {
@@ -33,6 +35,8 @@ pub enum Error {
     IoError(io::Error),
     NoAvailBuffers,
     SpuriousEvent,
+    /// Snapshot save/restore failed, or is unsupported by this device.
+    Snapshot(String),
 }
 
 /// Types of devices that can get attached to this platform.

--- a/src/devices/src/snapshot.rs
+++ b/src/devices/src/snapshot.rs
@@ -20,8 +20,24 @@ pub struct DeviceState {
 pub trait Snapshottable: Send {
     /// Stable identifier, used as the device's key in the snapshot.
     fn id(&self) -> &str;
-    /// Capture runtime state. Must be called with the device quiescent.
+
+    /// Quiesce the device so [`Snapshottable::save`] sees consistent state.
+    /// Stops the worker threads that own the live queue indices; must not drain
+    /// (a worker blocked on a stalled host fd would deadlock).
+    fn pause(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    /// Capture runtime state. Must be called after [`Snapshottable::pause`].
     fn save(&self) -> Result<DeviceState, Error>;
-    /// Restore from a previously captured state (used by M2 restore).
+
+    /// Load saved state, leaving the device quiesced (workers stopped).
     fn restore(&mut self, state: &DeviceState) -> Result<(), Error>;
+
+    /// Start the workers on the state loaded by [`Snapshottable::restore`].
+    /// Separate from `restore`: a worker raises IRQs as soon as it runs, and the
+    /// GIC blob (written later, on the vCPU thread) would overwrite them.
+    fn resume(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
 }

--- a/src/devices/src/snapshot.rs
+++ b/src/devices/src/snapshot.rs
@@ -1,0 +1,27 @@
+//! Device snapshot seam.
+//!
+//! Devices live in this crate, so the trait they implement lives here too (the
+//! VMM cannot be a dependency — it depends on us). The VMM orchestrates capture
+//! by iterating `dyn Snapshottable` and maps the returned bytes/errors into its
+//! snapshot format.
+
+use crate::Error;
+
+/// Opaque, independently-versioned per-device state. The device owns the byte
+/// layout; the orchestrator only frames it (id + length + version).
+pub struct DeviceState {
+    pub version: u8,
+    pub bytes: Vec<u8>,
+}
+
+/// A device that can serialize and restore its runtime state. Implemented by
+/// the virtio/legacy devices that must survive a snapshot; iterated as a trait
+/// object by the VMM, which is why it stays object-safe.
+pub trait Snapshottable: Send {
+    /// Stable identifier, used as the device's key in the snapshot.
+    fn id(&self) -> &str;
+    /// Capture runtime state. Must be called with the device quiescent.
+    fn save(&self) -> Result<DeviceState, Error>;
+    /// Restore from a previously captured state (used by M2 restore).
+    fn restore(&mut self, state: &DeviceState) -> Result<(), Error>;
+}

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -10,7 +10,7 @@ use super::super::{
     VirtioDevice,
 };
 use super::{defs, defs::uapi};
-use crate::virtio::InterruptTransport;
+use crate::virtio::{InterruptTransport, PauseError};
 #[cfg(target_os = "windows")]
 use windows_sys::Win32::System::Memory::DiscardVirtualMemory;
 
@@ -194,6 +194,12 @@ impl VirtioDevice for Balloon {
         self.device_state = DeviceState::Activated(mem, interrupt);
 
         Ok(())
+    }
+
+    /// Event-loop driven, and `Vmm::snapshot` runs on that loop, so nothing of
+    /// ours is running — just hand the queues over.
+    fn pause(&mut self) -> std::result::Result<Vec<DeviceQueue>, PauseError> {
+        Ok(self.queues.take().unwrap_or_default())
     }
 
     fn is_activated(&self) -> bool {

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -45,7 +45,7 @@ use super::{
 };
 
 use crate::virtio::{
-    ActivateError, InterruptTransport,
+    ActivateError, InterruptTransport, PauseError,
     block::{ImageType, SyncMode},
 };
 
@@ -234,7 +234,7 @@ pub struct Block {
     cache_type: CacheType,
     disk_image: Arc<Mutex<SyncFormatAccess<Box<dyn DynStorage>>>>,
     disk_image_id: Vec<u8>,
-    worker_thread: Option<JoinHandle<()>>,
+    worker_thread: Option<JoinHandle<DeviceQueue>>,
     worker_stopfd: EventFd,
 
     // Virtio fields.
@@ -456,6 +456,21 @@ impl VirtioDevice for Block {
 
         self.device_state = DeviceState::Activated(mem, interrupt);
         Ok(())
+    }
+
+    /// Stop the worker and take its queue back; it parks in `epoll` at a
+    /// descriptor boundary, so nothing is in flight.
+    fn pause(&mut self) -> std::result::Result<Vec<DeviceQueue>, PauseError> {
+        let Some(worker) = self.worker_thread.take() else {
+            return Ok(Vec::new());
+        };
+        self.worker_stopfd
+            .write(1)
+            .map_err(|e| PauseError::Failed(format!("virtio_blk stop: {e}")))?;
+        let queue = worker
+            .join()
+            .map_err(|_| PauseError::Failed("virtio_blk worker panicked".into()))?;
+        Ok(vec![queue])
     }
 
     fn reset(&mut self) -> bool {

--- a/src/devices/src/virtio/block/worker.rs
+++ b/src/devices/src/virtio/block/worker.rs
@@ -83,14 +83,15 @@ impl BlockWorker {
         }
     }
 
-    pub fn run(self) -> thread::JoinHandle<()> {
+    /// Returns its queue on stop, so the transport can snapshot the live indices.
+    pub fn run(self) -> thread::JoinHandle<DeviceQueue> {
         thread::Builder::new()
             .name("block worker".into())
             .spawn(|| self.work())
             .unwrap()
     }
 
-    fn work(mut self) {
+    fn work(mut self) -> DeviceQueue {
         let virtq_ev_fd = self.device_queue.event.as_raw_fd();
         let stop_ev_fd = self.stop_fd.as_raw_fd();
 
@@ -122,7 +123,7 @@ impl BlockWorker {
                             EventSet::IN if source == stop_ev_fd => {
                                 debug!("stopping worker thread");
                                 let _ = self.stop_fd.read();
-                                return;
+                                return self.device_queue;
                             }
                             _ => {
                                 log::warn!(

--- a/src/devices/src/virtio/console/device.rs
+++ b/src/devices/src/virtio/console/device.rs
@@ -1,4 +1,3 @@
-use bincode::{Decode, Encode};
 use std::cmp;
 use std::io::Write;
 use std::iter::zip;
@@ -16,7 +15,6 @@ use super::super::{
     ActivateError, ActivateResult, DeviceQueue, DeviceState, QueueConfig, VirtioDevice,
 };
 use super::{defs, defs::control_event, defs::uapi};
-use crate::snapshot::{DeviceState as SnapshotState, Snapshottable};
 use crate::virtio::console::console_control::{
     ConsoleControl, VirtioConsoleControl, VirtioConsoleResize,
 };
@@ -25,7 +23,7 @@ use crate::virtio::console::port::Port;
 use crate::virtio::console::port_queue_mapping::{
     QueueDirection, num_queues, port_id_to_queue_idx,
 };
-use crate::virtio::{InterruptTransport, PortDescription, QueueSnapshot, VmmExitObserver};
+use crate::virtio::{InterruptTransport, PortDescription, VmmExitObserver};
 
 pub(crate) const CONTROL_RXQ_INDEX: usize = 2;
 pub(crate) const CONTROL_TXQ_INDEX: usize = 3;
@@ -354,6 +352,32 @@ impl VirtioDevice for Console {
         self.device_state.is_activated()
     }
 
+    /// Restart per-port I/O threads after restore. On a fresh boot these start
+    /// from the guest's `PORT_OPEN` control message (see `process_control_tx`);
+    /// a guest restored at steady state already negotiated its ports and won't
+    /// resend, so start every port's threads here using the restored queues.
+    fn resume_after_restore(&mut self) {
+        let (mem, interrupt) = match &self.device_state {
+            DeviceState::Activated(mem, interrupt) => (mem.clone(), interrupt.clone()),
+            _ => return,
+        };
+        for port_id in 0..self.ports.len() {
+            let rx_idx = port_id_to_queue_idx(QueueDirection::Rx, port_id);
+            let tx_idx = port_id_to_queue_idx(QueueDirection::Tx, port_id);
+            let (Some(rx), Some(tx)) = (self.queues[rx_idx].take(), self.queues[tx_idx].take())
+            else {
+                continue;
+            };
+            self.ports[port_id].start(
+                mem.clone(),
+                rx.queue,
+                tx.queue,
+                interrupt.clone(),
+                self.control.clone(),
+            );
+        }
+    }
+
     fn reset(&mut self) -> bool {
         // Shutdown ports and clear queues.
         for port in &mut self.ports {
@@ -370,60 +394,5 @@ impl VmmExitObserver for Console {
     fn on_vmm_exit(&mut self) {
         self.reset();
         log::trace!("Console on_vmm_exit finished");
-    }
-}
-
-/// Version of the console snapshot encoding.
-const CONSOLE_SNAPSHOT_VERSION: u8 = 2;
-
-/// Resume-critical console state. Ports/threads/fds are rebuilt on restore.
-#[derive(Encode, Decode)]
-struct ConsoleState {
-    acked_features: u64,
-    activated: bool,
-    queues: Vec<Option<QueueSnapshot>>,
-}
-
-impl Snapshottable for Console {
-    fn id(&self) -> &str {
-        "console"
-    }
-
-    fn save(&self) -> std::result::Result<SnapshotState, crate::Error> {
-        let state = ConsoleState {
-            acked_features: self.acked_features,
-            activated: matches!(self.device_state, DeviceState::Activated(..)),
-            queues: self
-                .queues
-                .iter()
-                .map(|q| q.as_ref().map(|dq| dq.queue.snapshot()))
-                .collect(),
-        };
-        let bytes = bincode::encode_to_vec(&state, bincode::config::standard())
-            .map_err(|e| crate::Error::Snapshot(e.to_string()))?;
-        Ok(SnapshotState {
-            version: CONSOLE_SNAPSHOT_VERSION,
-            bytes,
-        })
-    }
-
-    fn restore(&mut self, state: &SnapshotState) -> std::result::Result<(), crate::Error> {
-        if state.version != CONSOLE_SNAPSHOT_VERSION {
-            return Err(crate::Error::Snapshot(format!(
-                "console: unsupported state version {}",
-                state.version
-            )));
-        }
-        let (cs, _): (ConsoleState, _) =
-            bincode::decode_from_slice(&state.bytes, bincode::config::standard())
-                .map_err(|e| crate::Error::Snapshot(format!("console: {e}")))?;
-        self.acked_features = cs.acked_features;
-        // cs.activated is informational until restore reactivates.
-        for (i, qs) in cs.queues.iter().enumerate() {
-            if let (Some(qs), Some(Some(dq))) = (qs, self.queues.get_mut(i)) {
-                dq.queue.restore(qs);
-            }
-        }
-        Ok(())
     }
 }

--- a/src/devices/src/virtio/console/device.rs
+++ b/src/devices/src/virtio/console/device.rs
@@ -1,3 +1,4 @@
+use bincode::{Decode, Encode};
 use std::cmp;
 use std::io::Write;
 use std::iter::zip;
@@ -15,6 +16,7 @@ use super::super::{
     ActivateError, ActivateResult, DeviceQueue, DeviceState, QueueConfig, VirtioDevice,
 };
 use super::{defs, defs::control_event, defs::uapi};
+use crate::snapshot::{DeviceState as SnapshotState, Snapshottable};
 use crate::virtio::console::console_control::{
     ConsoleControl, VirtioConsoleControl, VirtioConsoleResize,
 };
@@ -23,7 +25,7 @@ use crate::virtio::console::port::Port;
 use crate::virtio::console::port_queue_mapping::{
     QueueDirection, num_queues, port_id_to_queue_idx,
 };
-use crate::virtio::{InterruptTransport, PortDescription, VmmExitObserver};
+use crate::virtio::{InterruptTransport, PortDescription, QueueSnapshot, VmmExitObserver};
 
 pub(crate) const CONTROL_RXQ_INDEX: usize = 2;
 pub(crate) const CONTROL_TXQ_INDEX: usize = 3;
@@ -368,5 +370,60 @@ impl VmmExitObserver for Console {
     fn on_vmm_exit(&mut self) {
         self.reset();
         log::trace!("Console on_vmm_exit finished");
+    }
+}
+
+/// Version of the console snapshot encoding.
+const CONSOLE_SNAPSHOT_VERSION: u8 = 2;
+
+/// Resume-critical console state. Ports/threads/fds are rebuilt on restore.
+#[derive(Encode, Decode)]
+struct ConsoleState {
+    acked_features: u64,
+    activated: bool,
+    queues: Vec<Option<QueueSnapshot>>,
+}
+
+impl Snapshottable for Console {
+    fn id(&self) -> &str {
+        "console"
+    }
+
+    fn save(&self) -> std::result::Result<SnapshotState, crate::Error> {
+        let state = ConsoleState {
+            acked_features: self.acked_features,
+            activated: matches!(self.device_state, DeviceState::Activated(..)),
+            queues: self
+                .queues
+                .iter()
+                .map(|q| q.as_ref().map(|dq| dq.queue.snapshot()))
+                .collect(),
+        };
+        let bytes = bincode::encode_to_vec(&state, bincode::config::standard())
+            .map_err(|e| crate::Error::Snapshot(e.to_string()))?;
+        Ok(SnapshotState {
+            version: CONSOLE_SNAPSHOT_VERSION,
+            bytes,
+        })
+    }
+
+    fn restore(&mut self, state: &SnapshotState) -> std::result::Result<(), crate::Error> {
+        if state.version != CONSOLE_SNAPSHOT_VERSION {
+            return Err(crate::Error::Snapshot(format!(
+                "console: unsupported state version {}",
+                state.version
+            )));
+        }
+        let (cs, _): (ConsoleState, _) =
+            bincode::decode_from_slice(&state.bytes, bincode::config::standard())
+                .map_err(|e| crate::Error::Snapshot(format!("console: {e}")))?;
+        self.acked_features = cs.acked_features;
+        // cs.activated is informational until restore reactivates.
+        for (i, qs) in cs.queues.iter().enumerate() {
+            if let (Some(qs), Some(Some(dq))) = (qs, self.queues.get_mut(i)) {
+                dq.queue.restore(qs);
+            }
+        }
+        Ok(())
     }
 }

--- a/src/devices/src/virtio/console/device.rs
+++ b/src/devices/src/virtio/console/device.rs
@@ -12,7 +12,7 @@ use utils::eventfd::EventFd;
 use vm_memory::{ByteValued, Bytes, GuestMemoryMmap};
 
 use super::super::{
-    ActivateError, ActivateResult, DeviceQueue, DeviceState, QueueConfig, VirtioDevice,
+    ActivateError, ActivateResult, DeviceQueue, DeviceState, PauseError, QueueConfig, VirtioDevice,
 };
 use super::{defs, defs::control_event, defs::uapi};
 use crate::virtio::console::console_control::{
@@ -63,6 +63,9 @@ pub struct Console {
     queue_config: Vec<QueueConfig>,
     // Queues are stored as Option so individual queues can be taken when ports start.
     pub(crate) queues: Vec<Option<DeviceQueue>>,
+    // Ports the guest had open at snapshot. A restored guest won't re-send
+    // PORT_OPEN, so this is the only record of which to restart.
+    open_ports: Vec<bool>,
     // TODO: move the queue event handling to the correct threads!
     pub(crate) queue_events: Vec<Arc<EventFd>>,
 
@@ -99,6 +102,7 @@ impl Console {
             ports,
             queue_config,
             queues: Vec::new(),
+            open_ports: Vec::new(),
             queue_events: Vec::new(),
             avail_features: AVAIL_FEATURES,
             acked_features: 0,
@@ -352,16 +356,74 @@ impl VirtioDevice for Console {
         self.device_state.is_activated()
     }
 
-    /// Restart per-port I/O threads after restore. On a fresh boot these start
-    /// from the guest's `PORT_OPEN` control message (see `process_control_tx`);
-    /// a guest restored at steady state already negotiated its ports and won't
-    /// resend, so start every port's threads here using the restored queues.
-    fn resume_after_restore(&mut self) {
-        let (mem, interrupt) = match &self.device_state {
-            DeviceState::Activated(mem, interrupt) => (mem.clone(), interrupt.clone()),
-            _ => return,
-        };
+    /// Stop the ports' I/O threads and take their queues back — the threads own
+    /// the live indices.
+    fn pause(&mut self) -> std::result::Result<Vec<DeviceQueue>, PauseError> {
+        if !self.device_state.is_activated() {
+            return Ok(Vec::new());
+        }
+        self.open_ports = self.ports.iter().map(|p| p.is_active()).collect();
+
         for port_id in 0..self.ports.len() {
+            let recovered = self.ports[port_id].shutdown();
+            let rx_idx = port_id_to_queue_idx(QueueDirection::Rx, port_id);
+            let tx_idx = port_id_to_queue_idx(QueueDirection::Tx, port_id);
+            if let Some(queue) = recovered.rx {
+                self.queues[rx_idx] =
+                    Some(DeviceQueue::new(queue, self.queue_events[rx_idx].clone()));
+            }
+            if let Some(queue) = recovered.tx {
+                self.queues[tx_idx] =
+                    Some(DeviceQueue::new(queue, self.queue_events[tx_idx].clone()));
+            }
+        }
+
+        let mut queues = Vec::with_capacity(self.queues.len());
+        for (i, slot) in self.queues.iter_mut().enumerate() {
+            let queue = slot.take().ok_or_else(|| {
+                PauseError::Failed(format!("virtio_console queue {i} was not recovered"))
+            })?;
+            queues.push(queue);
+        }
+        Ok(queues)
+    }
+
+    /// One byte per port: whether the guest had it open. Always full width, even
+    /// if never activated (then `open_ports` is empty = nothing open).
+    fn save_state(&self) -> Vec<u8> {
+        (0..self.ports.len())
+            .map(|i| self.open_ports.get(i).copied().unwrap_or(false) as u8)
+            .collect()
+    }
+
+    fn restore_state(&mut self, state: &[u8]) -> std::result::Result<(), crate::Error> {
+        if state.len() != self.ports.len() {
+            return Err(crate::Error::Snapshot(format!(
+                "virtio_console: snapshot has {} ports, config has {}",
+                state.len(),
+                self.ports.len()
+            )));
+        }
+        self.open_ports = state.iter().map(|&b| b != 0).collect();
+        Ok(())
+    }
+
+    /// Bring the device back up, restarting only the ports the guest had open —
+    /// starting a closed port would consume the queue its later PORT_OPEN needs.
+    fn resume(
+        &mut self,
+        mem: GuestMemoryMmap,
+        interrupt: InterruptTransport,
+        queues: Vec<DeviceQueue>,
+    ) -> ActivateResult {
+        // activate signals `activate_evt`, which makes the event loop watch our
+        // queue eventfds; without it the guest's kick is never seen.
+        self.activate(mem.clone(), interrupt.clone(), queues)?;
+
+        for port_id in 0..self.ports.len() {
+            if !self.open_ports.get(port_id).copied().unwrap_or(false) {
+                continue;
+            }
             let rx_idx = port_id_to_queue_idx(QueueDirection::Rx, port_id);
             let tx_idx = port_id_to_queue_idx(QueueDirection::Tx, port_id);
             let (Some(rx), Some(tx)) = (self.queues[rx_idx].take(), self.queues[tx_idx].take())
@@ -376,6 +438,7 @@ impl VirtioDevice for Console {
                 self.control.clone(),
             );
         }
+        Ok(())
     }
 
     fn reset(&mut self) -> bool {

--- a/src/devices/src/virtio/console/port.rs
+++ b/src/devices/src/virtio/console/port.rs
@@ -64,8 +64,12 @@ enum PortState {
     Active {
         stopfd: utils::eventfd::EventFd,
         stop: Arc<AtomicBool>,
-        rx_thread: Option<JoinHandle<()>>,
-        tx_thread: Option<JoinHandle<()>>,
+        rx_thread: Option<JoinHandle<Queue>>,
+        tx_thread: Option<JoinHandle<Queue>>,
+        // Queues for a direction with no backing fd (an output-only port has no
+        // rx thread). Kept, not dropped, so a snapshot recovers every queue.
+        idle_rx: Option<Queue>,
+        idle_tx: Option<Queue>,
     },
 }
 
@@ -101,6 +105,11 @@ impl Port {
         self.terminal.as_deref()
     }
 
+    /// Whether the port's I/O threads are running (i.e. the guest opened it).
+    pub fn is_active(&self) -> bool {
+        matches!(self.state, PortState::Active { .. })
+    }
+
     pub fn notify_rx(&self) {
         if let PortState::Active {
             rx_thread: Some(handle),
@@ -130,7 +139,7 @@ impl Port {
         control: Arc<ConsoleControl>,
     ) {
         if let PortState::Active { .. } = &mut self.state {
-            self.shutdown();
+            let _ = self.shutdown();
         };
 
         let input = self.input.as_ref().cloned();
@@ -140,63 +149,105 @@ impl Port {
             .expect("Failed to create EventFd for interrupt_evt");
         let stop = Arc::new(AtomicBool::new(false));
 
-        let rx_thread = input.map(|input| {
-            let mem = mem.clone();
-            let interrupt = interrupt.clone();
-            let port_id = self.port_id;
-            let stopfd = stopfd.try_clone().unwrap();
-            let stop = stop.clone();
-            thread::Builder::new()
-                .name("console port".into())
-                .spawn(move || {
-                    process_rx(
-                        mem, rx_queue, interrupt, input, control, port_id, stopfd, stop,
-                    )
-                })
-                .unwrap()
-        });
+        let mut idle_rx = None;
+        let rx_thread = match input {
+            Some(input) => {
+                let mem = mem.clone();
+                let interrupt = interrupt.clone();
+                let port_id = self.port_id;
+                let stopfd = stopfd.try_clone().unwrap();
+                let stop = stop.clone();
+                Some(
+                    thread::Builder::new()
+                        .name("console port".into())
+                        .spawn(move || {
+                            process_rx(
+                                mem, rx_queue, interrupt, input, control, port_id, stopfd, stop,
+                            )
+                        })
+                        .unwrap(),
+                )
+            }
+            None => {
+                idle_rx = Some(rx_queue);
+                None
+            }
+        };
 
-        let tx_thread = output.map(|output| {
-            let stop = stop.clone();
-            thread::spawn(move || process_tx(mem, tx_queue, interrupt, output, stop))
-        });
+        let mut idle_tx = None;
+        let tx_thread = match output {
+            Some(output) => {
+                let stop = stop.clone();
+                let stopfd = stopfd.try_clone().unwrap();
+                Some(thread::spawn(move || {
+                    process_tx(mem, tx_queue, interrupt, output, stopfd, stop)
+                }))
+            }
+            None => {
+                idle_tx = Some(tx_queue);
+                None
+            }
+        };
 
         self.state = PortState::Active {
             stopfd,
             stop,
             rx_thread,
             tx_thread,
+            idle_rx,
+            idle_tx,
         }
     }
 
-    pub fn shutdown(&mut self) {
+    /// Stops the port's I/O threads and returns the queues they owned (each
+    /// `Option` since a port may have only one direction).
+    pub fn shutdown(&mut self) -> PortQueues {
+        let mut queues = PortQueues::default();
         if let PortState::Active {
             stopfd,
             stop,
             tx_thread,
             rx_thread,
+            idle_rx,
+            idle_tx,
         } = &mut self.state
         {
+            queues.rx = idle_rx.take();
+            queues.tx = idle_tx.take();
+            // Signal both wakeup paths before joining: the flag for the
+            // queue-pop park, and the stopfd for a tx thread blocked on a full
+            // output fd. Writing the stopfd after the tx join would deadlock.
             stop.store(true, Ordering::Release);
+            stopfd.write(1).unwrap();
             if let Some(tx_thread) = mem::take(tx_thread) {
                 tx_thread.thread().unpark();
-                if let Err(e) = tx_thread.join() {
-                    log::error!(
+                match tx_thread.join() {
+                    Ok(queue) => queues.tx = Some(queue),
+                    Err(e) => log::error!(
                         "Failed to flush tx for port {port_id}, thread panicked: {e:?}",
                         port_id = self.port_id
-                    )
+                    ),
                 }
             }
-            stopfd.write(1).unwrap();
             if let Some(rx_thread) = mem::take(rx_thread) {
                 rx_thread.thread().unpark();
-                if let Err(e) = rx_thread.join() {
-                    log::error!(
-                        "Failed to flush tx for port {port_id}, thread panicked: {e:?}",
+                match rx_thread.join() {
+                    Ok(queue) => queues.rx = Some(queue),
+                    Err(e) => log::error!(
+                        "Failed to flush rx for port {port_id}, thread panicked: {e:?}",
                         port_id = self.port_id
-                    )
+                    ),
                 }
             }
         };
+        self.state = PortState::Inactive;
+        queues
     }
+}
+
+/// The queues an active port's I/O threads owned, handed back on shutdown.
+#[derive(Default)]
+pub(crate) struct PortQueues {
+    pub rx: Option<Queue>,
+    pub tx: Option<Queue>,
 }

--- a/src/devices/src/virtio/console/port_io/mod.rs
+++ b/src/devices/src/virtio/console/port_io/mod.rs
@@ -22,7 +22,9 @@ pub trait PortInput {
 pub trait PortOutput {
     fn write_volatile(&mut self, buf: &VolatileSlice) -> Result<usize, io::Error>;
 
-    fn wait_until_writable(&self);
+    /// Block until the output can accept more, or until `stopfd` signals.
+    /// Returns true if it was `stopfd` that fired (the caller should stop).
+    fn wait_until_writable(&self, stopfd: Option<&EventFd>) -> bool;
 }
 
 /// Terminal properties associated with this port
@@ -84,7 +86,9 @@ impl PortOutput for PortOutputLog {
         Ok(buf.len())
     }
 
-    fn wait_until_writable(&self) {}
+    fn wait_until_writable(&self, _stopfd: Option<&EventFd>) -> bool {
+        false
+    }
 }
 
 pub struct PortInputEmpty {}

--- a/src/devices/src/virtio/console/port_io/unix.rs
+++ b/src/devices/src/virtio/console/port_io/unix.rs
@@ -145,9 +145,18 @@ impl PortOutput for PortOutputFd {
         })
     }
 
-    fn wait_until_writable(&self) {
-        let mut poll_fds = [PollFd::new(self.0.as_fd(), PollFlags::POLLOUT)];
+    fn wait_until_writable(&self, stopfd: Option<&EventFd>) -> bool {
+        let mut poll_fds = vec![PollFd::new(self.0.as_fd(), PollFlags::POLLOUT)];
+        if let Some(stopfd) = stopfd {
+            // SAFETY: we trust stopfd won't go away to avoid a dup call here.
+            let borrowed_fd = unsafe { BorrowedFd::borrow_raw(stopfd.as_raw_fd()) };
+            poll_fds.push(PollFd::new(borrowed_fd, PollFlags::POLLIN));
+        }
         poll(&mut poll_fds, PollTimeout::NONE).expect("Failed to poll");
+        poll_fds
+            .get(1)
+            .and_then(|pf| pf.revents())
+            .is_some_and(|r| r.intersects(PollFlags::POLLIN))
     }
 }
 

--- a/src/devices/src/virtio/console/port_io/windows.rs
+++ b/src/devices/src/virtio/console/port_io/windows.rs
@@ -141,10 +141,11 @@ impl PortOutput for PortOutputHandle {
         }
     }
 
-    fn wait_until_writable(&self) {
+    fn wait_until_writable(&self, _stopfd: Option<&EventFd>) -> bool {
         // Because WriteFile is blocking, `write_volatile` will natively pause the
         // thread until space is available. It will never return io::ErrorKind::WouldBlock.
         // Therefore, `process_tx` will never invoke this function on Windows.
+        false
     }
 }
 

--- a/src/devices/src/virtio/console/process_rx.rs
+++ b/src/devices/src/virtio/console/process_rx.rs
@@ -18,14 +18,14 @@ pub(crate) fn process_rx(
     port_id: u32,
     stopfd: utils::eventfd::EventFd,
     stop: Arc<AtomicBool>,
-) {
+) -> Queue {
     let mem = &mem;
     let mut eof = false;
 
     let mut input = input.lock().unwrap();
     loop {
         let Some(head) = pop_head_blocking(&mut queue, mem, &interrupt, &stop) else {
-            return;
+            return queue;
         };
 
         let head_index = head.index;
@@ -56,7 +56,7 @@ pub(crate) fn process_rx(
             interrupt.signal_used_queue();
             log::trace!("signaling EOF on port {port_id}");
             control.port_open(port_id, false);
-            return;
+            return queue;
         } else if bytes_read == 0 {
             queue.undo_pop();
             interrupt.signal_used_queue();
@@ -64,7 +64,7 @@ pub(crate) fn process_rx(
         }
 
         if stop.load(Ordering::Acquire) {
-            return;
+            return queue;
         }
     }
 }

--- a/src/devices/src/virtio/console/process_tx.rs
+++ b/src/devices/src/virtio/console/process_tx.rs
@@ -6,17 +6,19 @@ use vm_memory::{GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegio
 
 use crate::virtio::console::port_io::PortOutput;
 use crate::virtio::{DescriptorChain, InterruptTransport, Queue};
+use utils::eventfd::EventFd;
 
 pub(crate) fn process_tx(
     mem: GuestMemoryMmap,
     mut queue: Queue,
     interrupt: InterruptTransport,
     output: Arc<Mutex<Box<dyn PortOutput + Send>>>,
+    stopfd: EventFd,
     stop: Arc<AtomicBool>,
-) {
+) -> Queue {
     loop {
         let Some(head) = pop_head_blocking(&mut queue, &mem, &interrupt, &stop) else {
-            return;
+            return queue;
         };
 
         let head_index = head.index;
@@ -24,7 +26,7 @@ pub(crate) fn process_tx(
 
         for desc in head.into_iter().readable() {
             let desc_len = desc.len as usize;
-            match write_desc_to_output(desc, output.lock().unwrap().as_mut(), &interrupt) {
+            match write_desc_to_output(desc, output.lock().unwrap().as_mut(), &interrupt, &stopfd) {
                 Ok(0) => {
                     break;
                 }
@@ -39,10 +41,17 @@ pub(crate) fn process_tx(
                         // Errors could conceivably be spurious. Broken
                         // pipe is not and there is no point in attempting
                         // to write more.
-                        return;
+                        return queue;
                     }
                 }
             }
+        }
+
+        // Stopped mid-write: put the unfinished descriptor back (guest re-drives
+        // it on resume) and hand the queue back for the snapshot.
+        if stop.load(Ordering::Acquire) {
+            queue.undo_pop();
+            return queue;
         }
 
         if bytes_written == 0 {
@@ -82,6 +91,7 @@ fn write_desc_to_output(
     desc: DescriptorChain,
     output: &mut (dyn PortOutput + Send),
     interrupt: &InterruptTransport,
+    stopfd: &EventFd,
 ) -> Result<usize, GuestMemoryError> {
     // TODO: Switch to using `get_slices()` with the next vm-memory
     //       bump.
@@ -98,7 +108,11 @@ fn write_desc_to_output(
                     Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
                         log::trace!("Tx wait for output (would block)");
                         interrupt.signal_used_queue();
-                        output.wait_until_writable();
+                        // Abandon on stop, else a stalled host reader blocks the
+                        // snapshot forever.
+                        if output.wait_until_writable(Some(stopfd)) {
+                            break Ok(0);
+                        }
                     }
                     Err(e) => break Err(GuestMemoryError::IOError(e)),
                 }

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -165,12 +165,57 @@ pub trait VirtioDevice: AsAny + Send {
         None
     }
 
-    /// Re-establish worker state after a snapshot restore, once the transport has
-    /// re-activated the device with the restored queues. Default: no-op. A fresh
-    /// boot starts these from guest control-queue messages (e.g. console port
-    /// open); a guest restored at steady state has already sent them and won't
-    /// resend, so devices that spawn per-queue I/O threads must restart them.
-    fn resume_after_restore(&mut self) {}
+    /// Stop this device's workers and hand its live queues back for snapshot.
+    /// The workers own the running queue indices, so the transport cannot read
+    /// them until they stop. Must not drain in-flight work — a worker blocked on
+    /// a stalled host fd would deadlock; stop at a descriptor boundary. The
+    /// default rejects the snapshot.
+    fn pause(&mut self) -> std::result::Result<Vec<DeviceQueue>, PauseError> {
+        Err(PauseError::Unsupported(self.device_name().to_string()))
+    }
+
+    /// Device state beyond the queues (e.g. the console's open ports, which a
+    /// restored guest won't re-announce). Captured after [`VirtioDevice::pause`].
+    fn save_state(&self) -> Vec<u8> {
+        Vec::new()
+    }
+
+    /// Load what [`VirtioDevice::save_state`] wrote, before [`VirtioDevice::resume`].
+    fn restore_state(&mut self, _state: &[u8]) -> std::result::Result<(), crate::Error> {
+        Ok(())
+    }
+
+    /// Restart this device with `queues`, in place of [`VirtioDevice::activate`].
+    /// The default re-activates; override when resume differs from a fresh
+    /// activation (the console restarts only the ports the guest had open).
+    fn resume(
+        &mut self,
+        mem: GuestMemoryMmap,
+        interrupt: InterruptTransport,
+        queues: Vec<DeviceQueue>,
+    ) -> ActivateResult {
+        self.activate(mem, interrupt, queues)
+    }
+}
+
+/// Why a device could not be quiesced for a snapshot.
+#[derive(Debug)]
+pub enum PauseError {
+    /// The device has no quiesce support, so it cannot be snapshotted.
+    Unsupported(String),
+    /// The device tried to stop its workers and failed.
+    Failed(String),
+}
+
+impl std::fmt::Display for PauseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            PauseError::Unsupported(name) => {
+                write!(f, "device {name} does not support snapshot quiesce")
+            }
+            PauseError::Failed(e) => write!(f, "device quiesce failed: {e}"),
+        }
+    }
 }
 
 pub trait VmmExitObserver: Send {

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -164,6 +164,13 @@ pub trait VirtioDevice: AsAny + Send {
     fn shm_region(&self) -> Option<&VirtioShmRegion> {
         None
     }
+
+    /// Re-establish worker state after a snapshot restore, once the transport has
+    /// re-activated the device with the restored queues. Default: no-op. A fresh
+    /// boot starts these from guest control-queue messages (e.g. console port
+    /// open); a guest restored at steady state has already sent them and won't
+    /// resend, so devices that spawn per-queue I/O threads must restart them.
+    fn resume_after_restore(&mut self) {}
 }
 
 pub trait VmmExitObserver: Send {

--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -22,8 +22,8 @@ use super::passthrough;
 use super::virtual_entry::VirtualDirEntry;
 use super::worker::FsWorker;
 use super::{defs, defs::uapi};
-use crate::virtio::InterruptTransport;
 use crate::virtio::passthrough::PermissionSemantics;
+use crate::virtio::{InterruptTransport, PauseError};
 
 #[derive(Copy, Clone)]
 #[repr(C, packed)]
@@ -53,7 +53,7 @@ pub struct Fs {
     passthrough_cfg: Option<passthrough::Config>,
     read_only: bool,
     virtual_entries: Vec<VirtualDirEntry>,
-    worker_thread: Option<JoinHandle<()>>,
+    worker_thread: Option<JoinHandle<Vec<DeviceQueue>>>,
     worker_stopfd: EventFd,
     exit_code: Arc<AtomicI32>,
     #[cfg(target_os = "macos")]
@@ -248,5 +248,25 @@ impl VirtioDevice for Fs {
         }
         self.device_state = DeviceState::Inactive;
         true
+    }
+
+    /// Stop the worker and take its queues back; it parks in `epoll` at a
+    /// descriptor boundary, so nothing is in flight.
+    fn pause(&mut self) -> std::result::Result<Vec<DeviceQueue>, PauseError> {
+        // A DAX worker can park mid-`setupmapping` on a reply from the vmm worker
+        // thread, which needs the Vmm lock the snapshot holds — joining would
+        // deadlock. Refuse DAX until that path can be interrupted.
+        if self.shm_region.is_some() {
+            return Err(PauseError::Unsupported("virtio-fs with DAX".into()));
+        }
+        let Some(worker) = self.worker_thread.take() else {
+            return Ok(Vec::new());
+        };
+        self.worker_stopfd
+            .write(1)
+            .map_err(|e| PauseError::Failed(format!("virtio_fs stop: {e}")))?;
+        worker
+            .join()
+            .map_err(|_| PauseError::Failed("virtio_fs worker panicked".into()))
     }
 }

--- a/src/devices/src/virtio/fs/worker.rs
+++ b/src/devices/src/virtio/fs/worker.rs
@@ -16,7 +16,7 @@ use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 use utils::eventfd::EventFd;
 use vm_memory::GuestMemoryMmap;
 
-use super::super::{FsError, Queue};
+use super::super::{DeviceQueue, FsError, Queue};
 use super::augment_fs::AugmentFs;
 use super::defs::{HPQ_INDEX, REQ_INDEX};
 use super::descriptor_utils::{Reader, Writer};
@@ -145,14 +145,15 @@ impl FsWorker {
         })
     }
 
-    pub fn run(self) -> thread::JoinHandle<()> {
+    /// Returns its queues on stop, so the transport can snapshot the live indices.
+    pub fn run(self) -> thread::JoinHandle<Vec<DeviceQueue>> {
         thread::Builder::new()
             .name("fs worker".into())
             .spawn(|| self.work())
             .unwrap()
     }
 
-    fn work(mut self) {
+    fn work(mut self) -> Vec<DeviceQueue> {
         let virtq_hpq_ev_fd = self.queue_evts[HPQ_INDEX].as_raw_fd();
         let virtq_req_ev_fd = self.queue_evts[REQ_INDEX].as_raw_fd();
         let stop_ev_fd = self.stop_fd.as_raw_fd();
@@ -192,7 +193,12 @@ impl FsWorker {
                             EventSet::IN if source == stop_ev_fd => {
                                 debug!("stopping worker thread");
                                 let _ = self.stop_fd.read();
-                                return;
+                                return self
+                                    .queues
+                                    .into_iter()
+                                    .zip(self.queue_evts)
+                                    .map(|(queue, event)| DeviceQueue { queue, event })
+                                    .collect();
                             }
                             _ => {
                                 log::warn!(

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -17,8 +17,9 @@ use super::device_status;
 use super::*;
 use crate::bus::BusDevice;
 use crate::legacy::IrqChip;
+use crate::snapshot::{DeviceState, Snapshottable};
 use utils::{byte_order, eventfd::EventFd};
-use vm_memory::{GuestAddress, GuestMemoryMmap};
+use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
 
 //TODO crosvm uses 0 here, but IIRC virtio specified some other vendor id that should be used
 const VENDOR_ID: u32 = 0;
@@ -78,6 +79,12 @@ pub struct MmioTransport {
     queue_config: Vec<QueueConfig>,
     shm_region_select: u32,
     interrupt: InterruptTransport,
+    // Per-instance registration id, used as the snapshot key (id()).
+    name: String,
+    // Queue addresses/sizes captured at activation. The live queues are moved
+    // into the device (and then its worker threads), so this is the only place
+    // the transport can recover their config for a snapshot.
+    activated_queues: Vec<QueueSnapshot>,
 }
 
 struct InterruptTransportInner {
@@ -168,12 +175,17 @@ impl MmioTransport {
         mem: GuestMemoryMmap,
         intc: IrqChip,
         device: Arc<Mutex<dyn VirtioDevice>>,
+        id: String,
     ) -> Result<MmioTransport, CreateMmioTransportError> {
         let locked = device
             .try_lock()
             .expect("Mutex of VirtioDevice should not be locked when calling MmioTransport::new");
 
-        let debug_log_target = format!("{}[{}]", module_path!(), locked.device_name());
+        // The per-instance registration id (e.g. the block drive id, or "fs0"),
+        // not the device kind — snapshot keys device state by it, so it must be
+        // unique across devices of the same kind.
+        let name = id;
+        let debug_log_target = format!("{}[{}]", module_path!(), name);
         let queue_config: Vec<QueueConfig> = locked.queue_config().to_vec();
         drop(locked);
 
@@ -193,6 +205,8 @@ impl MmioTransport {
             queue_evts,
             queue_config,
             shm_region_select: 0,
+            name,
+            activated_queues: Vec::new(),
         })
     }
 
@@ -302,6 +316,10 @@ impl MmioTransport {
         let Some(queues) = self.queues.take() else {
             return;
         };
+
+        // Record the negotiated queue config before ownership passes to the
+        // device's worker threads, so a later snapshot can recover it.
+        self.activated_queues = queues.iter().map(|q| q.snapshot()).collect();
 
         let mut device_queues: Vec<DeviceQueue> = queues
             .into_iter()
@@ -527,6 +545,105 @@ impl BusDevice for MmioTransport {
     }
 }
 
+/// Version of the transport snapshot encoding.
+const TRANSPORT_SNAPSHOT_VERSION: u8 = 1;
+
+/// Resume-critical virtio-mmio negotiation state. The inner device's threads,
+/// fds, and per-port state are rebuilt by re-activation on restore.
+#[derive(bincode::Encode, bincode::Decode)]
+struct TransportState {
+    device_status: u32,
+    acked_features: u64,
+    queues: Vec<Option<QueueSnapshot>>,
+}
+
+impl Snapshottable for MmioTransport {
+    fn id(&self) -> &str {
+        &self.name
+    }
+
+    fn save(&self) -> Result<DeviceState, crate::Error> {
+        // The live queues' running indices are owned by the device's worker
+        // threads, but the vCPUs are frozen and the workers quiesced at snapshot
+        // time, so every consumed buffer has been returned: next_avail ==
+        // next_used == the guest's used-ring index. Recover the addresses from
+        // the activation-time config and the index from guest memory.
+        let queues = self
+            .activated_queues
+            .iter()
+            .map(|qs| {
+                let mut qs = *qs;
+                let used_idx: u16 = self
+                    .mem
+                    .read_obj(GuestAddress(qs.used_ring.wrapping_add(2)))
+                    .unwrap_or(0);
+                qs.next_avail = used_idx;
+                qs.next_used = used_idx;
+                Some(qs)
+            })
+            .collect();
+        let state = TransportState {
+            device_status: self.device_status,
+            acked_features: self.locked_device().acked_features(),
+            queues,
+        };
+        let bytes = bincode::encode_to_vec(&state, bincode::config::standard())
+            .map_err(|e| crate::Error::Snapshot(e.to_string()))?;
+        Ok(DeviceState {
+            version: TRANSPORT_SNAPSHOT_VERSION,
+            bytes,
+        })
+    }
+
+    /// Rebuild the negotiated queues and re-activate the device. The guest wrote
+    /// DRIVER_OK before the snapshot and resumes past it, so the transport never
+    /// sees that write again — without re-activating here the device's worker
+    /// threads never start and the guest's queue notifications go unanswered.
+    fn restore(&mut self, state: &DeviceState) -> Result<(), crate::Error> {
+        if state.version != TRANSPORT_SNAPSHOT_VERSION {
+            return Err(crate::Error::Snapshot(format!(
+                "mmio transport: unsupported state version {}",
+                state.version
+            )));
+        }
+        let (ts, _): (TransportState, _) =
+            bincode::decode_from_slice(&state.bytes, bincode::config::standard())
+                .map_err(|e| crate::Error::Snapshot(format!("mmio transport: {e}")))?;
+
+        self.locked_device().set_acked_features(ts.acked_features);
+
+        // Rebuild the queues from saved state (addresses, indices, ready bits)
+        // before activation moves them into the device.
+        let mut queues = Self::create_queues(&self.queue_config);
+        for (queue, snapshot) in queues.iter_mut().zip(&ts.queues) {
+            if let Some(snapshot) = snapshot {
+                queue.restore(snapshot);
+            }
+        }
+        // The ring addresses/size come from an untrusted snapshot; the workers
+        // assume validated queues (they `unwrap()` guest-memory access), so a
+        // ready queue that fails validation must fail the restore, not panic
+        // later on the first kick.
+        for queue in queues.iter().filter(|q| q.ready) {
+            if !queue.is_valid(&self.mem) {
+                return Err(crate::Error::Snapshot(
+                    "mmio transport: restored queue failed validation".into(),
+                ));
+            }
+        }
+        self.queues = Some(queues);
+        self.device_status = ts.device_status;
+
+        if (ts.device_status & device_status::DRIVER_OK) != 0
+            && !self.locked_device().is_activated()
+        {
+            self.activate();
+            self.locked_device().resume_after_restore();
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use utils::byte_order::{read_le_u32, write_le_u32};
@@ -619,8 +736,13 @@ pub(crate) mod tests {
     fn test_new() {
         let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         let dummy = DummyDevice::new();
-        let mut d =
-            MmioTransport::new(m, DummyIrqChip::new().into(), Arc::new(Mutex::new(dummy))).unwrap();
+        let mut d = MmioTransport::new(
+            m,
+            DummyIrqChip::new().into(),
+            Arc::new(Mutex::new(dummy)),
+            "test".into(),
+        )
+        .unwrap();
 
         // We just make sure here that the implementation of a mmio device behaves as we expect,
         // given a known virtio device implementation (the dummy device).
@@ -650,6 +772,7 @@ pub(crate) mod tests {
             m,
             DummyIrqChip::new().into(),
             Arc::new(Mutex::new(DummyDevice::new())),
+            "test".into(),
         )
         .unwrap();
 
@@ -730,7 +853,13 @@ pub(crate) mod tests {
     fn test_bus_device_write() {
         let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
         let dummy_dev = Arc::new(Mutex::new(DummyDevice::new()));
-        let mut d = MmioTransport::new(m, DummyIrqChip::new().into(), dummy_dev.clone()).unwrap();
+        let mut d = MmioTransport::new(
+            m,
+            DummyIrqChip::new().into(),
+            dummy_dev.clone(),
+            "test".into(),
+        )
+        .unwrap();
         let mut buf = vec![0; 5];
         write_le_u32(&mut buf[..4], 1);
 
@@ -891,6 +1020,7 @@ pub(crate) mod tests {
             m,
             DummyIrqChip::new().into(),
             Arc::new(Mutex::new(DummyDevice::new())),
+            "test".into(),
         )
         .unwrap();
 
@@ -1004,6 +1134,7 @@ pub(crate) mod tests {
             m,
             DummyIrqChip::new().into(),
             Arc::new(Mutex::new(DummyDevice::new())),
+            "test".into(),
         )
         .unwrap();
         let mut buf = [0; 4];

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -19,7 +19,7 @@ use crate::bus::BusDevice;
 use crate::legacy::IrqChip;
 use crate::snapshot::{DeviceState, Snapshottable};
 use utils::{byte_order, eventfd::EventFd};
-use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory::{GuestAddress, GuestMemoryMmap};
 
 //TODO crosvm uses 0 here, but IIRC virtio specified some other vendor id that should be used
 const VENDOR_ID: u32 = 0;
@@ -81,10 +81,10 @@ pub struct MmioTransport {
     interrupt: InterruptTransport,
     // Per-instance registration id, used as the snapshot key (id()).
     name: String,
-    // Queue addresses/sizes captured at activation. The live queues are moved
-    // into the device (and then its worker threads), so this is the only place
-    // the transport can recover their config for a snapshot.
+    // Queue config captured at activation; the live queues move into the device.
     activated_queues: Vec<QueueSnapshot>,
+    // Live queues a paused device handed back — the authoritative snapshot state.
+    paused_queues: Option<Vec<DeviceQueue>>,
 }
 
 struct InterruptTransportInner {
@@ -207,6 +207,7 @@ impl MmioTransport {
             shm_region_select: 0,
             name,
             activated_queues: Vec::new(),
+            paused_queues: None,
         })
     }
 
@@ -546,7 +547,7 @@ impl BusDevice for MmioTransport {
 }
 
 /// Version of the transport snapshot encoding.
-const TRANSPORT_SNAPSHOT_VERSION: u8 = 1;
+const TRANSPORT_SNAPSHOT_VERSION: u8 = 3;
 
 /// Resume-critical virtio-mmio negotiation state. The inner device's threads,
 /// fds, and per-port state are rebuilt by re-activation on restore.
@@ -554,7 +555,12 @@ const TRANSPORT_SNAPSHOT_VERSION: u8 = 1;
 struct TransportState {
     device_status: u32,
     acked_features: u64,
+    // virtio-mmio InterruptStatus: an unacked used-buffer IRQ must survive, or
+    // the restored handler reads 0 and never reaps the ring.
+    interrupt_status: u32,
     queues: Vec<Option<QueueSnapshot>>,
+    // Opaque device-specific state (see `VirtioDevice::save_state`).
+    device: Vec<u8>,
 }
 
 impl Snapshottable for MmioTransport {
@@ -562,30 +568,41 @@ impl Snapshottable for MmioTransport {
         &self.name
     }
 
-    fn save(&self) -> Result<DeviceState, crate::Error> {
-        // The live queues' running indices are owned by the device's worker
-        // threads, but the vCPUs are frozen and the workers quiesced at snapshot
-        // time, so every consumed buffer has been returned: next_avail ==
-        // next_used == the guest's used-ring index. Recover the addresses from
-        // the activation-time config and the index from guest memory.
+    fn pause(&mut self) -> Result<(), crate::Error> {
+        if !self.locked_device().is_activated() {
+            return Ok(());
+        }
         let queues = self
-            .activated_queues
-            .iter()
-            .map(|qs| {
-                let mut qs = *qs;
-                let used_idx: u16 = self
-                    .mem
-                    .read_obj(GuestAddress(qs.used_ring.wrapping_add(2)))
-                    .unwrap_or(0);
-                qs.next_avail = used_idx;
-                qs.next_used = used_idx;
-                Some(qs)
-            })
-            .collect();
+            .locked_device()
+            .pause()
+            .map_err(|e| crate::Error::Snapshot(format!("{}: {e}", self.name)))?;
+        self.paused_queues = Some(queues);
+        Ok(())
+    }
+
+    fn save(&self) -> Result<DeviceState, crate::Error> {
+        // Snapshot the indices off the paused queues, not the running device.
+        let queues: Vec<Option<QueueSnapshot>> = if self.locked_device().is_activated() {
+            let Some(paused) = &self.paused_queues else {
+                return Err(crate::Error::Snapshot(format!(
+                    "{}: save before pause; the device's workers still own the queues",
+                    self.name
+                )));
+            };
+            paused.iter().map(|dq| Some(dq.queue.snapshot())).collect()
+        } else {
+            Vec::new()
+        };
+        // Separate lets: two `locked_device()` temporaries in one struct literal
+        // would both be live and self-deadlock on the device mutex.
+        let acked_features = self.locked_device().acked_features();
+        let device = self.locked_device().save_state();
         let state = TransportState {
             device_status: self.device_status,
-            acked_features: self.locked_device().acked_features(),
+            acked_features,
+            interrupt_status: self.interrupt.status().load(Ordering::SeqCst) as u32,
             queues,
+            device,
         };
         let bytes = bincode::encode_to_vec(&state, bincode::config::standard())
             .map_err(|e| crate::Error::Snapshot(e.to_string()))?;
@@ -595,10 +612,6 @@ impl Snapshottable for MmioTransport {
         })
     }
 
-    /// Rebuild the negotiated queues and re-activate the device. The guest wrote
-    /// DRIVER_OK before the snapshot and resumes past it, so the transport never
-    /// sees that write again — without re-activating here the device's worker
-    /// threads never start and the guest's queue notifications go unanswered.
     fn restore(&mut self, state: &DeviceState) -> Result<(), crate::Error> {
         if state.version != TRANSPORT_SNAPSHOT_VERSION {
             return Err(crate::Error::Snapshot(format!(
@@ -611,19 +624,31 @@ impl Snapshottable for MmioTransport {
                 .map_err(|e| crate::Error::Snapshot(format!("mmio transport: {e}")))?;
 
         self.locked_device().set_acked_features(ts.acked_features);
+        self.interrupt
+            .status()
+            .store(ts.interrupt_status as usize, Ordering::SeqCst);
 
-        // Rebuild the queues from saved state (addresses, indices, ready bits)
-        // before activation moves them into the device.
+        // Reject a short queue list: the zip below would leave the missing queues
+        // zeroed (and not `ready`, so is_valid skips them) and the device would
+        // silently answer nothing.
+        if (ts.device_status & device_status::DRIVER_OK) != 0
+            && ts.queues.len() != self.queue_config.len()
+        {
+            return Err(crate::Error::Snapshot(format!(
+                "mmio transport: snapshot has {} queues, device has {}",
+                ts.queues.len(),
+                self.queue_config.len()
+            )));
+        }
+
         let mut queues = Self::create_queues(&self.queue_config);
         for (queue, snapshot) in queues.iter_mut().zip(&ts.queues) {
             if let Some(snapshot) = snapshot {
                 queue.restore(snapshot);
             }
         }
-        // The ring addresses/size come from an untrusted snapshot; the workers
-        // assume validated queues (they `unwrap()` guest-memory access), so a
-        // ready queue that fails validation must fail the restore, not panic
-        // later on the first kick.
+        // Ring addresses come from an untrusted snapshot; workers `unwrap()`
+        // guest-memory access, so validate before use, don't panic on first kick.
         for queue in queues.iter().filter(|q| q.ready) {
             if !queue.is_valid(&self.mem) {
                 return Err(crate::Error::Snapshot(
@@ -631,14 +656,46 @@ impl Snapshottable for MmioTransport {
                 ));
             }
         }
-        self.queues = Some(queues);
         self.device_status = ts.device_status;
+        self.locked_device().restore_state(&ts.device)?;
 
         if (ts.device_status & device_status::DRIVER_OK) != 0
             && !self.locked_device().is_activated()
         {
-            self.activate();
-            self.locked_device().resume_after_restore();
+            // Hold the queues for `resume`, which runs after the vCPUs restore
+            // the GIC — a worker started now would raise IRQs the GIC blob wipes.
+            self.activated_queues = queues.iter().map(|q| q.snapshot()).collect();
+            let event_idx_enabled = (ts.acked_features & (1 << VIRTIO_RING_F_EVENT_IDX)) != 0;
+            self.paused_queues = Some(
+                queues
+                    .into_iter()
+                    .zip(self.queue_evts.iter().cloned())
+                    .map(|(mut queue, event)| {
+                        queue.set_event_idx(event_idx_enabled);
+                        DeviceQueue::new(queue, event)
+                    })
+                    .collect(),
+            );
+        } else {
+            self.queues = Some(queues);
+        }
+        Ok(())
+    }
+
+    fn resume(&mut self) -> Result<(), crate::Error> {
+        let Some(queues) = self.paused_queues.take() else {
+            return Ok(());
+        };
+        let (mem, interrupt) = (self.mem.clone(), self.interrupt.clone());
+        self.locked_device()
+            .resume(mem, interrupt, queues)
+            .map_err(|e| crate::Error::Snapshot(format!("{}: device resume: {e:?}", self.name)))?;
+
+        // Kick every queue: the restored eventfds start at 0, and a descriptor
+        // the guest made available but the worker hadn't consumed left no
+        // notification behind (and won't be re-kicked under suppression).
+        for event in &self.queue_evts {
+            let _ = event.write(1);
         }
         Ok(())
     }

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -51,7 +51,7 @@ pub use self::gpu::*;
 pub use self::mmio::*;
 #[cfg(feature = "net")]
 pub use self::net::Net;
-pub use self::queue::{Descriptor, DescriptorChain, Queue};
+pub use self::queue::{Descriptor, DescriptorChain, Queue, QueueSnapshot};
 #[cfg(not(feature = "tee"))]
 pub use self::rng::*;
 #[cfg(feature = "vhost-user")]

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -5,6 +5,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+use bincode::{Decode, Encode};
 use std::cmp::min;
 use std::fmt::{self, Debug, Display};
 use std::num::Wrapping;
@@ -705,6 +706,50 @@ impl Queue {
             .map(Wrapping)
             .map_err(Error::GuestMemory)
     }
+
+    /// Capture the queue's runtime state for snapshot. `max_size` is omitted —
+    /// it's fixed at construction from the device config.
+    pub fn snapshot(&self) -> QueueSnapshot {
+        QueueSnapshot {
+            size: self.size,
+            ready: self.ready,
+            desc_table: self.desc_table.raw_value(),
+            avail_ring: self.avail_ring.raw_value(),
+            used_ring: self.used_ring.raw_value(),
+            next_avail: self.next_avail.0,
+            next_used: self.next_used.0,
+            event_idx_enabled: self.event_idx_enabled,
+            num_added: self.num_added.0,
+        }
+    }
+
+    /// Restore runtime state captured by [`Queue::snapshot`].
+    pub fn restore(&mut self, s: &QueueSnapshot) {
+        self.size = s.size;
+        self.ready = s.ready;
+        self.desc_table = GuestAddress(s.desc_table);
+        self.avail_ring = GuestAddress(s.avail_ring);
+        self.used_ring = GuestAddress(s.used_ring);
+        self.next_avail = Wrapping(s.next_avail);
+        self.next_used = Wrapping(s.next_used);
+        self.event_idx_enabled = s.event_idx_enabled;
+        self.num_added = Wrapping(s.num_added);
+    }
+}
+
+/// Serializable virtqueue runtime state. Encoded with bincode by the owning
+/// device; no hand-maintained offsets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+pub struct QueueSnapshot {
+    pub size: u16,
+    pub ready: bool,
+    pub desc_table: u64,
+    pub avail_ring: u64,
+    pub used_ring: u64,
+    pub next_avail: u16,
+    pub next_used: u16,
+    pub event_idx_enabled: bool,
+    pub num_added: u16,
 }
 
 #[cfg(test)]
@@ -714,6 +759,27 @@ pub(crate) mod tests {
 
     pub use super::*;
     use vm_memory::{GuestAddress, GuestMemoryMmap};
+
+    #[test]
+    fn queue_snapshot_round_trips() {
+        let s = QueueSnapshot {
+            size: 256,
+            ready: true,
+            desc_table: 0x1000,
+            avail_ring: 0x2000,
+            used_ring: 0x3000,
+            next_avail: 5,
+            next_used: 7,
+            event_idx_enabled: true,
+            num_added: 3,
+        };
+        let cfg = bincode::config::standard();
+        let b = bincode::encode_to_vec(s, cfg).unwrap();
+        let (back, _): (QueueSnapshot, _) = bincode::decode_from_slice(&b, cfg).unwrap();
+        assert_eq!(back, s);
+        // Truncated input is rejected, not mis-decoded.
+        assert!(bincode::decode_from_slice::<QueueSnapshot, _>(&b[..b.len() - 1], cfg).is_err());
+    }
 
     // Represents a location in GuestMemoryMmap which holds a given type.
     pub struct SomeplaceInMemory<'a, T> {

--- a/src/devices/src/virtio/rng/device.rs
+++ b/src/devices/src/virtio/rng/device.rs
@@ -6,7 +6,7 @@ use super::super::{
     ActivateError, ActivateResult, DeviceQueue, DeviceState, QueueConfig, RngError, VirtioDevice,
 };
 use super::{defs, defs::uapi};
-use crate::virtio::InterruptTransport;
+use crate::virtio::{InterruptTransport, PauseError};
 
 // Request queue.
 pub(crate) const REQ_INDEX: usize = 0;
@@ -144,6 +144,12 @@ impl VirtioDevice for Rng {
         self.device_state = DeviceState::Activated(mem, interrupt);
 
         Ok(())
+    }
+
+    /// Event-loop driven, and `Vmm::snapshot` runs on that loop, so nothing of
+    /// ours is running — just hand the queues over.
+    fn pause(&mut self) -> std::result::Result<Vec<DeviceQueue>, PauseError> {
+        Ok(self.queues.take().unwrap_or_default())
     }
 
     fn is_activated(&self) -> bool {

--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -113,6 +113,7 @@ pub enum Error {
     VcpuReadRegister,
     VcpuReadSystemRegister,
     VcpuRequestExit,
+    RestoreInvalidRegister(u32),
     VcpuRun,
     VcpuSetPendingIrq,
     VcpuSetRegister,
@@ -139,6 +140,9 @@ impl Display for Error {
             VcpuReadRegister => write!(f, "Error reading HVF vCPU register"),
             VcpuReadSystemRegister => write!(f, "Error reading HVF vCPU system register"),
             VcpuRequestExit => write!(f, "Error requesting HVF vCPU exit"),
+            RestoreInvalidRegister(r) => {
+                write!(f, "Snapshot has unknown system register id 0x{r:x}")
+            }
             VcpuRun => write!(f, "Error running HVF vCPU"),
             VcpuSetPendingIrq => write!(f, "Error setting HVF vCPU pending irq"),
             VcpuSetRegister => write!(f, "Error setting HVF vCPU register"),
@@ -193,6 +197,47 @@ pub fn vcpu_set_pending_irq(
         Err(Error::VcpuSetPendingIrq)
     } else {
         Ok(())
+    }
+}
+
+/// Vtimer offset that keeps the guest's CNTVCT continuous across a snapshot.
+/// The guest counter at capture was `host_counter - captured_offset` (CNTVCT =
+/// `mach_absolute_time() - offset`); to resume the guest at that same value the
+/// new offset is `now - host_counter + captured_offset`. Computed once from the
+/// primary vCPU's capture and shared across all vCPUs (CNTVCT is system-wide).
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+pub fn shared_vtimer_offset(host_counter: u64, captured_offset: u64) -> u64 {
+    vtimer_offset_for(
+        unsafe { mach_absolute_time() },
+        host_counter,
+        captured_offset,
+    )
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+fn vtimer_offset_for(now: u64, host_counter: u64, captured_offset: u64) -> u64 {
+    now.saturating_sub(host_counter)
+        .saturating_add(captured_offset)
+}
+
+#[cfg(all(test, target_arch = "aarch64", target_os = "macos"))]
+mod vtimer_tests {
+    use super::vtimer_offset_for;
+
+    // The guest's CNTVCT is `now - offset`. Restoring must reproduce the value
+    // the guest saw at capture (`host_counter - captured_offset`), regardless of
+    // how much host time passed in between.
+    #[test]
+    fn restore_preserves_guest_counter() {
+        for &(host_counter, captured_offset, now) in &[
+            (1_000u64, 0u64, 5_000u64), // fresh capture (offset 0)
+            (1_000, 300, 5_000),        // captured after a pause
+            (10_000, 2_500, 10_000),    // no host time elapsed
+        ] {
+            let guest_at_capture = host_counter - captured_offset;
+            let offset = vtimer_offset_for(now, host_counter, captured_offset);
+            assert_eq!(now - offset, guest_at_capture);
+        }
     }
 }
 
@@ -327,7 +372,9 @@ pub struct HvfVcpu<'a> {
     mmio_buf: [u8; 8],
     pending_mmio_read: Option<MmioRead>,
     pending_advance_pc: bool,
-    vtimer_masked: bool,
+    // `Cell` so the `&self` restore path can update this mirror of the HVF vtimer
+    // mask alongside the hardware register.
+    vtimer_masked: Cell<bool>,
     nested_enabled: bool,
     // Cached copy of the HVF vtimer offset (0 until a live pause advances it),
     // so the WFE deadline check doesn't issue a syscall on every wait.
@@ -488,7 +535,7 @@ impl HvfVcpu<'_> {
             mmio_buf: [0; 8],
             pending_mmio_read: None,
             pending_advance_pc: false,
-            vtimer_masked: false,
+            vtimer_masked: Cell::new(false),
             nested_enabled,
             vtimer_offset: Cell::new(0),
         })
@@ -685,8 +732,54 @@ impl HvfVcpu<'_> {
         })
     }
 
+    /// Restore register state from [`HvfVcpu::save_state`] onto this fresh vCPU,
+    /// on its own thread before the first `run()`. ICC state is restored
+    /// separately via `hv_gic_*`. `vtimer_offset` (`now - host_counter`, shared
+    /// across vCPUs) keeps CNTVCT continuous, so armed deadlines don't fire en
+    /// masse to catch up the snapshot gap.
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    pub fn restore_state(&self, state: &HvfVcpuState, vtimer_offset: u64) -> Result<(), Error> {
+        for (&r, &v) in SAVED_GP.iter().zip(&state.gp) {
+            self.write_reg(r, v)?;
+        }
+        for &(r, v) in &state.sysregs {
+            // Snapshot data is untrusted: only restore registers we capture, so a
+            // malformed snapshot can't write an arbitrary system register.
+            if !SAVED_SYSREGS.iter().any(|&s| s as u32 == r) {
+                return Err(Error::RestoreInvalidRegister(r));
+            }
+            let ret = unsafe { hv_vcpu_set_sys_reg(self.vcpuid, r as u16, v) };
+            if ret != HV_SUCCESS {
+                return Err(Error::VcpuSetSystemRegister(r as u16, v));
+            }
+        }
+        let ret = unsafe { hv_vcpu_set_vtimer_offset(self.vcpuid, vtimer_offset) };
+        if ret != HV_SUCCESS {
+            return Err(Error::VcpuSetRegister);
+        }
+        self.vtimer_offset.set(vtimer_offset);
+        let ret = unsafe { hv_vcpu_set_vtimer_mask(self.vcpuid, state.vtimer_mask) };
+        if ret != HV_SUCCESS {
+            return Err(Error::VcpuSetVtimerMask);
+        }
+        // Keep the mirror in sync so hvf_sync_vtimer re-arms a restored-masked
+        // vtimer instead of skipping it forever.
+        self.vtimer_masked.set(state.vtimer_mask);
+        self.write_reg(hv_reg_t_HV_REG_FPCR, state.fpcr)?;
+        self.write_reg(hv_reg_t_HV_REG_FPSR, state.fpsr)?;
+        for (q, &val) in state.simd.iter().enumerate() {
+            let ret = unsafe {
+                hv_vcpu_set_simd_fp_reg(self.vcpuid, q as u32, val as hv_simd_fp_uchar16_t)
+            };
+            if ret != HV_SUCCESS {
+                return Err(Error::VcpuSetRegister);
+            }
+        }
+        Ok(())
+    }
+
     fn hvf_sync_vtimer(&mut self, vcpu_list: Arc<dyn Vcpus>) {
-        if !self.vtimer_masked {
+        if !self.vtimer_masked.get() {
             return;
         }
 
@@ -698,7 +791,7 @@ impl HvfVcpu<'_> {
         vcpu_list.set_vtimer_irq(self.vcpuid);
         if !irq_state {
             vcpu_set_vtimer_mask(self.vcpuid, false).unwrap();
-            self.vtimer_masked = false;
+            self.vtimer_masked.set(false);
         }
     }
 
@@ -767,7 +860,7 @@ impl HvfVcpu<'_> {
         match self.vcpu_exit.reason {
             HV_EXIT_REASON_EXCEPTION => { /* This is the main one, handle below. */ }
             HV_EXIT_REASON_VTIMER_ACTIVATED => {
-                self.vtimer_masked = true;
+                self.vtimer_masked.set(true);
                 return Ok(VcpuExit::VtimerActivated);
             }
             HV_EXIT_REASON_CANCELED => return Ok(VcpuExit::Canceled),
@@ -891,14 +984,10 @@ impl HvfVcpu<'_> {
 
                 // Also CNTV_CVAL & CNTV_CVAL_EL0
                 let cval = self.read_sys_reg(hv_sys_reg_t_HV_SYS_REG_CNTV_CVAL_EL0)?;
-                // The guest's deadline `cval` is in the CNTVCT domain, where
-                // CNTVCT = mach_absolute_time() - vtimer_offset. The offset is 0
-                // on a fresh boot but nonzero after a live pause (it keeps CNTVCT
-                // continuous across the paused interval). Compare against the
-                // corrected counter, not raw mach time — otherwise after a pause
-                // `now` runs ahead of every armed deadline and the vCPU busy-loops
-                // on WaitForEventExpired instead of parking, so the guest's virtual
-                // timer never fires and timed sleeps hang.
+                // `cval` is in the CNTVCT domain (mach time - vtimer_offset), so
+                // compare against the corrected counter; using raw mach time after
+                // a pause/restore busy-loops on WaitForEventExpired and the vtimer
+                // never fires.
                 let now = unsafe { mach_absolute_time() }.saturating_sub(self.vtimer_offset.get());
                 if now > cval {
                     return Ok(VcpuExit::WaitForEventExpired);

--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -334,6 +334,117 @@ pub struct HvfVcpu<'a> {
     vtimer_offset: Cell<u64>,
 }
 
+/// GP registers captured for snapshot, in order: X0..X30, PC, CPSR (33 entries).
+/// SP_EL0/EL1 are captured as sysregs; X29=FP, X30=LR.
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+const SAVED_GP: &[hv_reg_t] = &[
+    hv_reg_t_HV_REG_X0,
+    hv_reg_t_HV_REG_X1,
+    hv_reg_t_HV_REG_X2,
+    hv_reg_t_HV_REG_X3,
+    hv_reg_t_HV_REG_X4,
+    hv_reg_t_HV_REG_X5,
+    hv_reg_t_HV_REG_X6,
+    hv_reg_t_HV_REG_X7,
+    hv_reg_t_HV_REG_X8,
+    hv_reg_t_HV_REG_X9,
+    hv_reg_t_HV_REG_X10,
+    hv_reg_t_HV_REG_X11,
+    hv_reg_t_HV_REG_X12,
+    hv_reg_t_HV_REG_X13,
+    hv_reg_t_HV_REG_X14,
+    hv_reg_t_HV_REG_X15,
+    hv_reg_t_HV_REG_X16,
+    hv_reg_t_HV_REG_X17,
+    hv_reg_t_HV_REG_X18,
+    hv_reg_t_HV_REG_X19,
+    hv_reg_t_HV_REG_X20,
+    hv_reg_t_HV_REG_X21,
+    hv_reg_t_HV_REG_X22,
+    hv_reg_t_HV_REG_X23,
+    hv_reg_t_HV_REG_X24,
+    hv_reg_t_HV_REG_X25,
+    hv_reg_t_HV_REG_X26,
+    hv_reg_t_HV_REG_X27,
+    hv_reg_t_HV_REG_X28,
+    hv_reg_t_HV_REG_X29,
+    hv_reg_t_HV_REG_X30,
+    hv_reg_t_HV_REG_PC,
+    hv_reg_t_HV_REG_CPSR,
+];
+
+/// EL1 guest-resume sysreg set + generic timer. MPIDR_EL1 is set at vCPU
+/// create, not here. The pointer-auth keys (AP*KEY*) MUST be captured: the
+/// kernel signs return addresses with them, and a restored vCPU with different
+/// keys faults on `autiasp`.
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+const SAVED_SYSREGS: &[hv_sys_reg_t] = &[
+    hv_sys_reg_t_HV_SYS_REG_SCTLR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_TTBR0_EL1,
+    hv_sys_reg_t_HV_SYS_REG_TTBR1_EL1,
+    hv_sys_reg_t_HV_SYS_REG_TCR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_MAIR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_AMAIR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_VBAR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_SP_EL0,
+    hv_sys_reg_t_HV_SYS_REG_SP_EL1,
+    hv_sys_reg_t_HV_SYS_REG_ELR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_SPSR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_ESR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_FAR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_CONTEXTIDR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_TPIDR_EL0,
+    hv_sys_reg_t_HV_SYS_REG_TPIDR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_TPIDRRO_EL0,
+    hv_sys_reg_t_HV_SYS_REG_CPACR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_CSSELR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_AFSR0_EL1,
+    hv_sys_reg_t_HV_SYS_REG_AFSR1_EL1,
+    hv_sys_reg_t_HV_SYS_REG_PAR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_MDSCR_EL1,
+    hv_sys_reg_t_HV_SYS_REG_CNTV_CTL_EL0,
+    hv_sys_reg_t_HV_SYS_REG_CNTV_CVAL_EL0,
+    hv_sys_reg_t_HV_SYS_REG_CNTKCTL_EL1,
+    hv_sys_reg_t_HV_SYS_REG_CNTP_CTL_EL0,
+    hv_sys_reg_t_HV_SYS_REG_CNTP_CVAL_EL0,
+    hv_sys_reg_t_HV_SYS_REG_APIAKEYLO_EL1,
+    hv_sys_reg_t_HV_SYS_REG_APIAKEYHI_EL1,
+    hv_sys_reg_t_HV_SYS_REG_APIBKEYLO_EL1,
+    hv_sys_reg_t_HV_SYS_REG_APIBKEYHI_EL1,
+    hv_sys_reg_t_HV_SYS_REG_APDAKEYLO_EL1,
+    hv_sys_reg_t_HV_SYS_REG_APDAKEYHI_EL1,
+    hv_sys_reg_t_HV_SYS_REG_APDBKEYLO_EL1,
+    hv_sys_reg_t_HV_SYS_REG_APDBKEYHI_EL1,
+    hv_sys_reg_t_HV_SYS_REG_APGAKEYLO_EL1,
+    hv_sys_reg_t_HV_SYS_REG_APGAKEYHI_EL1,
+];
+
+/// Captured HVF vCPU register state, hypervisor-side. The VMM maps this into
+/// its arch-neutral snapshot type; HVF register ids never leave this crate.
+///
+/// Per-vCPU GIC CPU-interface (ICC) registers are captured separately alongside
+/// the GIC distributor/redistributor blob, because those use the dynamically
+/// loaded `hv_gic_*` symbols rather than the statically linked `hv_vcpu_*` set.
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[derive(Debug, Clone)]
+pub struct HvfVcpuState {
+    /// One value per `SAVED_GP` entry, in order.
+    pub gp: Vec<u64>,
+    /// (sys_reg id, value) per `SAVED_SYSREGS` entry.
+    pub sysregs: Vec<(u32, u64)>,
+    /// Q0..Q31 NEON/FP registers.
+    pub simd: Vec<u128>,
+    /// FP control / status registers.
+    pub fpcr: u64,
+    pub fpsr: u64,
+    /// Virtual timer mask + offset at capture.
+    pub vtimer_mask: bool,
+    pub vtimer_offset: u64,
+    /// `mach_absolute_time()` at capture — the anchor used to recompute the
+    /// vtimer offset on restore so the guest's CNTVCT stays continuous.
+    pub host_counter: u64,
+}
+
 impl HvfVcpu<'_> {
     pub fn new(mpidr: u64, nested_enabled: bool) -> Result<Self, Error> {
         let mut vcpuid: hv_vcpu_t = 0;
@@ -525,6 +636,53 @@ impl HvfVcpu<'_> {
         }
         self.vtimer_offset.set(offset);
         Ok(())
+    }
+
+    /// Capture this vCPU's architectural register state for snapshot. Uses only
+    /// the statically linked `hv_vcpu_*` symbols; per-vCPU GIC (ICC) state goes
+    /// through the dynamically loaded `hv_gic_*` path instead. Must be called
+    /// from the vCPU's own thread while it is parked between guest runs.
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    pub fn save_state(&self) -> Result<HvfVcpuState, Error> {
+        let gp = SAVED_GP
+            .iter()
+            .map(|&r| self.read_reg(r))
+            .collect::<Result<Vec<_>, _>>()?;
+        let sysregs = SAVED_SYSREGS
+            .iter()
+            .map(|&r| Ok((r as u32, self.read_sys_reg(r)?)))
+            .collect::<Result<Vec<_>, Error>>()?;
+        let simd = (0u32..32)
+            .map(|q| {
+                let mut val: hv_simd_fp_uchar16_t = 0;
+                let ret = unsafe { hv_vcpu_get_simd_fp_reg(self.vcpuid, q, &mut val) };
+                if ret != HV_SUCCESS {
+                    Err(Error::VcpuReadRegister)
+                } else {
+                    Ok(val)
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let fpcr = self.read_reg(hv_reg_t_HV_REG_FPCR)?;
+        let fpsr = self.read_reg(hv_reg_t_HV_REG_FPSR)?;
+
+        let mut vtimer_mask = false;
+        let ret = unsafe { hv_vcpu_get_vtimer_mask(self.vcpuid, &mut vtimer_mask) };
+        if ret != HV_SUCCESS {
+            return Err(Error::VcpuReadRegister);
+        }
+        let host_counter = unsafe { mach_absolute_time() };
+
+        Ok(HvfVcpuState {
+            gp,
+            sysregs,
+            simd,
+            fpcr,
+            fpsr,
+            vtimer_mask,
+            vtimer_offset: self.vtimer_offset.get(),
+            host_counter,
+        })
     }
 
     fn hvf_sync_vtimer(&mut self, vcpu_list: Arc<dyn Vcpus>) {

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -2845,6 +2845,14 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
     #[cfg(feature = "aws-nitro")]
     return krun_start_enter_nitro(ctx_id);
 
+    enter_vmm(ctx_id, None)
+}
+
+/// Build the microVM from a ctx and run its event loop (blocking). When
+/// `restore` is set, the VM is hydrated from that snapshot directory instead of
+/// booted.
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+fn enter_vmm(ctx_id: u32, restore: Option<PathBuf>) -> i32 {
     let mut event_manager = match EventManager::new() {
         Ok(em) => em,
         Err(e) => {
@@ -2957,6 +2965,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         &mut event_manager,
         ctx_cfg.shutdown_efd,
         sender,
+        restore,
     ) {
         Ok(vmm) => vmm,
         Err(e) => {
@@ -3042,6 +3051,43 @@ pub extern "C" fn krun_vm_resume(_ctx_id: u32) -> i32 {
     -libc::ENOTSUP
 }
 
+/// Restore a VM from the snapshot at `c_snapshot_path` and run it. `ctx_id` must
+/// be an already-configured context whose shape (arch, memory, vCPU count)
+/// matches the snapshot's manifest; this validates that, hydrates guest RAM,
+/// device, and vCPU state onto it, then enters the guest (blocking, like
+/// `krun_start_enter`). `flags` is reserved and must be 0.
+#[cfg(all(target_os = "macos", not(any(feature = "tee", feature = "aws-nitro"))))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn krun_restore(
+    ctx_id: u32,
+    c_snapshot_path: *const c_char,
+    flags: u32,
+) -> i32 {
+    if flags != 0 || c_snapshot_path.is_null() {
+        return -libc::EINVAL;
+    }
+    let path = match unsafe { CStr::from_ptr(c_snapshot_path) }.to_str() {
+        Ok(p) => PathBuf::from(p),
+        Err(e) => {
+            error!("Error parsing snapshot path: {e:?}");
+            return -libc::EINVAL;
+        }
+    };
+    enter_vmm(ctx_id, Some(path))
+}
+
+#[cfg(not(all(target_os = "macos", not(any(feature = "tee", feature = "aws-nitro")))))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn krun_restore(
+    _ctx_id: u32,
+    _c_snapshot_path: *const c_char,
+    _flags: u32,
+) -> i32 {
+    -libc::ENOTSUP
+}
+
 /// Thread-safe out-of-band snapshot of a VM running under `krun_start_enter` on
 /// another thread. The VM's event loop freezes the vCPUs, writes the snapshot to
 /// `c_snapshot_path` and exits the process (`KRUN_SNAPSHOT_EXIT`).
@@ -3063,6 +3109,9 @@ pub unsafe extern "C" fn krun_snapshot_request(
             return -libc::EINVAL;
         }
     };
+    if c_snapshot_path.is_null() {
+        return -libc::EINVAL;
+    }
     let path = match unsafe { CStr::from_ptr(c_snapshot_path) }.to_str() {
         Ok(p) => PathBuf::from(p),
         Err(e) => {

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -51,6 +51,8 @@ use vmm::resources::{
     DefaultVirtioConsoleConfig, PortConfig, SerialConsoleConfig, TsiFlags, VirtioConsoleConfigMode,
     VmResources, VsockConfig,
 };
+#[cfg(all(target_os = "macos", not(any(feature = "tee", feature = "aws-nitro"))))]
+use vmm::snapshot::SnapshotFlags;
 #[cfg(feature = "blk")]
 use vmm::vmm_config::block::{BlockDeviceConfig, BlockRootConfig};
 #[cfg(not(feature = "tee"))]
@@ -431,8 +433,8 @@ static CTX_MAP: Lazy<Mutex<HashMap<u32, ContextConfig>>> = Lazy::new(|| Mutex::n
 static CTX_IDS: AtomicI32 = AtomicI32::new(0);
 
 /// Out-of-band control channel for running VMs, keyed by ctx id. Populated by
-/// `krun_start_enter` for every macOS VM so `krun_vm_pause` / `krun_vm_resume`
-/// can reach it from another thread.
+/// `krun_start_enter` for every macOS VM so `krun_vm_pause`, `krun_vm_resume`
+/// and `krun_snapshot_request` can reach it from another thread.
 #[cfg(target_os = "macos")]
 static VM_CTL: Lazy<Mutex<HashMap<u32, PollableChannelSender<VmCtl>>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
@@ -2977,7 +2979,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
     vmm::worker::start_worker_thread(_vmm.clone(), _receiver.clone()).unwrap();
 
     // Register the control channel for every macOS VM so another thread can
-    // freeze/wake this guest while `krun_start_enter` blocks here.
+    // freeze, wake or snapshot this guest while `krun_start_enter` blocks here.
     #[cfg(target_os = "macos")]
     VM_CTL
         .lock()
@@ -3037,6 +3039,48 @@ pub extern "C" fn krun_vm_pause(_ctx_id: u32) -> i32 {
 #[cfg(not(target_os = "macos"))]
 #[unsafe(no_mangle)]
 pub extern "C" fn krun_vm_resume(_ctx_id: u32) -> i32 {
+    -libc::ENOTSUP
+}
+
+/// Thread-safe out-of-band snapshot of a VM running under `krun_start_enter` on
+/// another thread. The VM's event loop freezes the vCPUs, writes the snapshot to
+/// `c_snapshot_path` and exits the process (`KRUN_SNAPSHOT_EXIT`).
+#[cfg(all(target_os = "macos", not(any(feature = "tee", feature = "aws-nitro"))))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn krun_snapshot_request(
+    ctx_id: u32,
+    c_snapshot_path: *const c_char,
+    flags: u32,
+) -> i32 {
+    // M1 supports `Exit` only; `Resume` is accepted by the ABI but not yet
+    // implemented.
+    let flags = match SnapshotFlags::from_bits(flags) {
+        Some(SnapshotFlags::Exit) => SnapshotFlags::Exit,
+        Some(SnapshotFlags::Resume) => return -libc::ENOTSUP,
+        None => {
+            error!("Unknown snapshot flags: {flags}");
+            return -libc::EINVAL;
+        }
+    };
+    let path = match unsafe { CStr::from_ptr(c_snapshot_path) }.to_str() {
+        Ok(p) => PathBuf::from(p),
+        Err(e) => {
+            error!("Error parsing snapshot path: {e:?}");
+            return -libc::EINVAL;
+        }
+    };
+    send_vm_ctl(ctx_id, VmCtl::Snapshot(path, flags))
+}
+
+#[cfg(not(all(target_os = "macos", not(any(feature = "tee", feature = "aws-nitro")))))]
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn krun_snapshot_request(
+    _ctx_id: u32,
+    _c_snapshot_path: *const c_char,
+    _flags: u32,
+) -> i32 {
     -libc::ENOTSUP
 }
 

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/containers/libkrun"
 
 [features]
 tee = ["devices/tee", "arch/tee"]
-amd-sev = ["blk", "bitfield", "bitflags", "iocuddle", "tee", "kbs-types", "devices/amd-sev", "arch/amd-sev"]
-tdx = ["blk", "tee", "kbs-types", "dep:tdx", "devices/tdx", "arch/tdx", "cpuid/tdx"]
+amd-sev = ["blk", "bitfield", "bitflags", "iocuddle", "tee", "kbs-types", "serde", "serde_json", "devices/amd-sev", "arch/amd-sev"]
+tdx = ["blk", "tee", "kbs-types", "serde", "serde_json", "dep:tdx", "devices/tdx", "arch/tdx", "cpuid/tdx"]
 net = ["devices/net"]
 blk = ["devices/blk"]
 gpu = ["devices/gpu", "krun_display"]
@@ -40,8 +40,8 @@ polly = { package = "krun-polly", version = "=0.1.0-2.0.0-dev", path = "../polly
 
 # Dependencies for amd-sev
 kbs-types = { version = "0.13.0", optional = true }
-serde = { version = "1.0.125", features = ["derive"] }
-serde_json = { version = "1.0.64" }
+serde = { version = "1.0.125", features = ["derive"], optional = true }
+serde_json = { version = "1.0.64", optional = true }
 iocuddle = { version = "0.1.1", optional = true }
 bitfield = { version = "0.19.4", optional = true }
 bitflags = { version = "2.10.0", optional = true }
@@ -61,6 +61,9 @@ kvm-ioctls = "0.24"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 hvf = { package = "krun-hvf", version = "=0.1.0-2.0.0-dev", path = "../hvf" }
+# The snapshot module (macOS/HVF only) serializes its manifest with serde.
+serde = { version = "1.0.125", features = ["derive"] }
+serde_json = { version = "1.0.64" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61.2", features = [

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/containers/libkrun"
 
 [features]
 tee = ["devices/tee", "arch/tee"]
-amd-sev = ["blk", "bitfield", "bitflags", "iocuddle", "tee", "kbs-types", "serde", "serde_json", "devices/amd-sev", "arch/amd-sev"]
-tdx = ["blk", "tee", "kbs-types", "serde", "serde_json", "dep:tdx", "devices/tdx", "arch/tdx", "cpuid/tdx"]
+amd-sev = ["blk", "bitfield", "bitflags", "iocuddle", "tee", "kbs-types", "devices/amd-sev", "arch/amd-sev"]
+tdx = ["blk", "tee", "kbs-types", "dep:tdx", "devices/tdx", "arch/tdx", "cpuid/tdx"]
 net = ["devices/net"]
 blk = ["devices/blk"]
 gpu = ["devices/gpu", "krun_display"]
@@ -20,6 +20,7 @@ aws-nitro = []
 vhost-user = ["devices/vhost-user"]
 
 [dependencies]
+bincode = { version = "2.0.1", default-features = false, features = ["std", "derive"] }
 crossbeam-channel = ">=0.5.15"
 flate2 = "1.0.35"
 libc = ">=0.2.39"
@@ -39,8 +40,8 @@ polly = { package = "krun-polly", version = "=0.1.0-2.0.0-dev", path = "../polly
 
 # Dependencies for amd-sev
 kbs-types = { version = "0.13.0", optional = true }
-serde = { version = "1.0.125", optional = true }
-serde_json = { version = "1.0.64", optional = true }
+serde = { version = "1.0.125", features = ["derive"] }
+serde_json = { version = "1.0.64" }
 iocuddle = { version = "0.1.1", optional = true }
 bitfield = { version = "0.19.4", optional = true }
 bitflags = { version = "2.10.0", optional = true }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -82,6 +82,8 @@ use crate::vmm_config::kernel_cmdline::DEFAULT_KERNEL_CMDLINE;
 use crate::vstate::KvmContext;
 #[cfg(all(target_os = "linux", feature = "tee"))]
 use crate::vstate::MeasuredRegion;
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+use crate::vstate::VcpuResponse;
 use crate::vstate::{Error as VstateError, Vcpu, VcpuConfig, Vm};
 use arch::{ArchMemoryInfo, InitrdConfig};
 use device_manager::shm::ShmManager;
@@ -1190,7 +1192,7 @@ pub fn build_microvm(
     // before the vCPUs run. `configure_system` above wrote a fresh FDT/cmdline;
     // the snapshot RAM image overwrites it with the captured contents.
     #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-    if let Some(dir) = restore_from {
+    if let Some(dir) = restore_from.as_ref() {
         // The snapshot captures only EL1 sysregs, and the restore path skips
         // set_initial_state (which programs the EL2 registers). A nested VM would
         // resume with EL2 config at reset defaults, so reject it outright.
@@ -1199,7 +1201,7 @@ pub fn build_microvm(
                 "restore of a nested-virtualization VM is not supported".into(),
             ));
         }
-        apply_restore(&vmm, &mut vcpus, &dir)?;
+        apply_restore(&vmm, &mut vcpus, dir)?;
     }
     #[cfg(not(all(target_arch = "aarch64", target_os = "macos")))]
     if restore_from.is_some() {
@@ -1210,6 +1212,33 @@ pub fn build_microvm(
 
     vmm.start_vcpus(vcpus)
         .map_err(StartMicrovmError::Internal)?;
+
+    // Resume device workers only after the vCPUs restore the GIC (on their own
+    // threads): a worker raises IRQs at once, and the GIC blob would wipe them.
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    if restore_from.is_some() {
+        for handle in vmm.vcpus_handles.iter() {
+            match handle.response_receiver().recv() {
+                Ok(VcpuResponse::Restored) => {}
+                Ok(other) => {
+                    return Err(StartMicrovmError::Restore(format!(
+                        "unexpected vcpu response while restoring: {other:?}"
+                    )));
+                }
+                Err(e) => {
+                    return Err(StartMicrovmError::Restore(format!(
+                        "vcpu restore response: {e:?}"
+                    )));
+                }
+            }
+        }
+        for dev in vmm.mmio_device_manager.snapshottables() {
+            dev.lock()
+                .unwrap()
+                .resume()
+                .map_err(|e| StartMicrovmError::Restore(format!("device resume: {e:?}")))?;
+        }
+    }
 
     // Clippy thinks we don't need Arc<Mutex<...
     // but we don't want to change the event_manager interface

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -176,6 +176,8 @@ pub enum StartMicrovmError {
     InitrdRead(io::Error),
     /// Internal error encountered while starting a microVM.
     Internal(Error),
+    /// Failed to restore the VM from a snapshot.
+    Restore(String),
     /// Cannot inject the kernel into the guest memory due to a problem with the bundle.
     InvalidKernelBundle(vm_memory::mmap::MmapRegionError),
     /// The kernel command line is invalid.
@@ -341,6 +343,7 @@ impl Display for StartMicrovmError {
             ),
             InitrdRead(ref err) => write!(f, "Cannot load initrd due to an invalid image: {err}"),
             Internal(ref err) => write!(f, "Internal error while starting microVM: {err:?}"),
+            Restore(ref msg) => write!(f, "Failed to restore VM from snapshot: {msg}"),
             InvalidKernelBundle(ref err) => {
                 let mut err_msg = format!("{err}");
                 err_msg = err_msg.replace('\"', "");
@@ -585,6 +588,7 @@ pub fn build_microvm(
     event_manager: &mut EventManager,
     _shutdown_efd: Option<EventFd>,
     _sender: Sender<WorkerMessage>,
+    restore_from: Option<std::path::PathBuf>,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
     let payload = choose_payload(vm_resources)?;
 
@@ -1180,6 +1184,28 @@ pub fn build_microvm(
         }
 
         println!("Starting TEE/microVM.");
+    }
+
+    // Restore path: hydrate guest RAM, devices, and vCPU state from the snapshot
+    // before the vCPUs run. `configure_system` above wrote a fresh FDT/cmdline;
+    // the snapshot RAM image overwrites it with the captured contents.
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    if let Some(dir) = restore_from {
+        // The snapshot captures only EL1 sysregs, and the restore path skips
+        // set_initial_state (which programs the EL2 registers). A nested VM would
+        // resume with EL2 config at reset defaults, so reject it outright.
+        if vm_resources.nested_enabled {
+            return Err(StartMicrovmError::Restore(
+                "restore of a nested-virtualization VM is not supported".into(),
+            ));
+        }
+        apply_restore(&vmm, &mut vcpus, &dir)?;
+    }
+    #[cfg(not(all(target_arch = "aarch64", target_os = "macos")))]
+    if restore_from.is_some() {
+        return Err(StartMicrovmError::Restore(
+            "snapshot restore is only supported on macOS/aarch64".into(),
+        ));
     }
 
     vmm.start_vcpus(vcpus)
@@ -2083,6 +2109,117 @@ fn create_vcpus_aarch64(
     Ok(vcpus)
 }
 
+/// Hydrate a freshly-built VM from a snapshot directory: validate the config
+/// against the manifest, overwrite guest RAM with the captured image, restore
+/// device state, and stage each vCPU's register/GIC state so its thread resumes
+/// the guest instead of booting. Runs after the devices and vCPUs are built but
+/// before `start_vcpus`.
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+fn apply_restore(
+    vmm: &Vmm,
+    vcpus: &mut [Vcpu],
+    dir: &std::path::Path,
+) -> std::result::Result<(), StartMicrovmError> {
+    use crate::macos::vstate::VcpuRestore;
+    use crate::snapshot::{RestoreInput, SnapErr, load_mem_image};
+    use hvf::HvfVcpuState;
+    use vm_memory::{GuestMemory, GuestMemoryRegion};
+
+    let err = |e: SnapErr| StartMicrovmError::Restore(format!("{e:?}"));
+    let input = RestoreInput::read(dir).map_err(err)?;
+
+    // Config-validate: the freshly-built VM shape (incl. ordered device topology)
+    // must match the snapshot. Device kind alone isn't unique, so the ordered
+    // kinds are the contract and device state is matched to devices by position.
+    let mem_mib = vmm.guest_memory().iter().map(|r| r.len()).sum::<u64>() / (1 << 20);
+    let live_kinds: Vec<String> = vmm
+        .mmio_device_manager
+        .snapshottables()
+        .iter()
+        .map(|d| d.lock().unwrap().id().to_string())
+        .collect();
+    input
+        .manifest
+        .validate(
+            "aarch64",
+            "hvf",
+            mem_mib as usize,
+            vcpus.len() as u8,
+            &live_kinds.iter().map(String::as_str).collect::<Vec<_>>(),
+        )
+        .map_err(err)?;
+
+    // Multi-vCPU restore is not implemented: the global GIC blob must be restored
+    // once after every redistributor exists (a barrier across the vCPU threads),
+    // and all vCPUs must share one vtimer offset (CNTVCT is system-wide). Reject
+    // it rather than silently dropping secondary GIC state.
+    if input.vmstate.vcpus.len() > 1 {
+        return Err(StartMicrovmError::Restore(format!(
+            "multi-vCPU restore is not supported yet (snapshot has {} vcpus)",
+            input.vmstate.vcpus.len()
+        )));
+    }
+
+    // Overwrite guest RAM with the captured image.
+    let mut img = File::open(&input.mem_path)
+        .map_err(|e| StartMicrovmError::Restore(format!("open memory.img: {e}")))?;
+    load_mem_image(vmm.guest_memory(), &mut img).map_err(err)?;
+
+    // Restore device state by position: validate() already confirmed the ordered
+    // device topology matches, so saved section i belongs to live device i.
+    if input.vmstate.devices.len() != live_kinds.len() {
+        return Err(StartMicrovmError::Restore(format!(
+            "snapshot has {} device sections, config has {}",
+            input.vmstate.devices.len(),
+            live_kinds.len()
+        )));
+    }
+    for (dev, (kind, state)) in vmm
+        .mmio_device_manager
+        .snapshottables()
+        .iter()
+        .zip(&input.vmstate.devices)
+    {
+        let mut dev = dev.lock().unwrap();
+        if dev.id() != kind {
+            return Err(StartMicrovmError::Restore(format!(
+                "device section kind mismatch: snapshot={kind}, config={}",
+                dev.id()
+            )));
+        }
+        dev.restore(state)
+            .map_err(|e| StartMicrovmError::Restore(format!("device {}: {e:?}", dev.id())))?;
+    }
+
+    // Attach per-vCPU restore; vCPU 0 also restores the global GIC blob.
+    if input.vmstate.vcpus.len() != vcpus.len() {
+        return Err(StartMicrovmError::Restore(format!(
+            "snapshot has {} vcpus, config has {}",
+            input.vmstate.vcpus.len(),
+            vcpus.len()
+        )));
+    }
+    for (i, (vcpu, state)) in vcpus.iter_mut().zip(input.vmstate.vcpus).enumerate() {
+        let hvf_state = HvfVcpuState {
+            gp: state.gp.to_vec(),
+            sysregs: state.sysregs,
+            simd: state.simd.to_vec(),
+            fpcr: state.fpcr,
+            fpsr: state.fpsr,
+            vtimer_mask: state.vtimer.mask,
+            vtimer_offset: state.vtimer.offset,
+            host_counter: state.host_counter,
+        };
+        let gic = (i == 0).then(|| input.vmstate.gic.clone());
+        vcpu.set_restore(VcpuRestore {
+            state: hvf_state,
+            icc: state.icc,
+            gic,
+        });
+    }
+    Ok(())
+}
+
 #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
 fn create_vcpus_riscv64(
     vm: &Vm,
@@ -2108,32 +2245,49 @@ fn create_vcpus_riscv64(
     Ok(vcpus)
 }
 
-/// Attaches an virtio mmio device to the device manager.
+/// Attaches an virtio mmio device to the device manager. Returns the transport
+/// so the caller can register it as a snapshot participant.
 fn attach_mmio_device(
     vmm: &mut Vmm,
     id: String,
     intc: IrqChip,
     device: Arc<Mutex<dyn VirtioDevice>>,
-) -> std::result::Result<(), device_manager::mmio::Error> {
-    let mmio_device = MmioTransport::new(vmm.guest_memory().clone(), intc, device)?;
+) -> std::result::Result<Arc<Mutex<MmioTransport>>, device_manager::mmio::Error> {
+    let mmio_device = Arc::new(Mutex::new(MmioTransport::new(
+        vmm.guest_memory().clone(),
+        intc,
+        device,
+        id.clone(),
+    )?));
 
-    let type_id = mmio_device.locked_device().device_type();
+    let type_id = mmio_device.lock().unwrap().locked_device().device_type();
     let _cmdline = &mut vmm.kernel_cmdline;
 
     #[cfg(target_os = "linux")]
-    let (_mmio_base, _irq) =
-        vmm.mmio_device_manager
-            .register_mmio_device(vmm.vm.fd(), mmio_device, type_id, id)?;
+    let (_mmio_base, _irq) = vmm.mmio_device_manager.register_mmio_device(
+        vmm.vm.fd(),
+        mmio_device.clone(),
+        type_id,
+        id,
+    )?;
     #[cfg(target_os = "macos")]
     let (_mmio_base, _irq) =
         vmm.mmio_device_manager
-            .register_mmio_device(mmio_device, type_id, id)?;
+            .register_mmio_device(mmio_device.clone(), type_id, id)?;
 
     #[cfg(target_arch = "x86_64")]
     vmm.mmio_device_manager
         .add_device_to_cmdline(_cmdline, _mmio_base, _irq)?;
 
-    Ok(())
+    // Every virtio device participates in the snapshot via its transport: the
+    // guest expects them all live after a restore, and reboot/shutdown touches
+    // each (e.g. a filesystem sync on virtiofs), so leaving any unrestored hangs
+    // the resumed guest.
+    #[cfg(target_os = "macos")]
+    vmm.mmio_device_manager
+        .add_snapshottable(mmio_device.clone());
+
+    Ok(mmio_device)
 }
 
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
@@ -2564,9 +2718,6 @@ fn attach_console_devices(
 
     vmm.exit_observers.push(console.clone());
 
-    #[cfg(target_os = "macos")]
-    vmm.mmio_device_manager.add_snapshottable(console.clone());
-
     event_manager
         .add_subscriber(console.clone())
         .map_err(RegisterEvent)?;
@@ -2576,6 +2727,7 @@ fn attach_console_devices(
         .map_err(RegisterFsSigwinch)?;
 
     // The device mutex mustn't be locked here otherwise it will deadlock.
+    // attach_mmio_device registers the transport as a snapshot participant.
     attach_mmio_device(vmm, format!("hvc{id_number}"), intc, console)
         .map_err(RegisterConsoleDevice)?;
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -838,7 +838,8 @@ pub fn build_microvm(
         Arc::new(VcpuList::new(cpu_count as u64))
     };
 
-    let vcpus;
+    #[allow(unused_mut)]
+    let mut vcpus;
     let intc: IrqChip;
     // For x86_64 we need to create the interrupt controller before calling `KVM_CREATE_VCPUS`
     // while on aarch64 we need to do it the other way around.
@@ -950,6 +951,11 @@ pub fn build_microvm(
         )
         .map_err(StartMicrovmError::Internal)?;
 
+        // Each vCPU captures its own thread-affine GIC (ICC) state at snapshot.
+        for vcpu in &mut vcpus {
+            vcpu.set_intc(intc.clone());
+        }
+
         attach_legacy_devices(
             &vm,
             &mut mmio_device_manager,
@@ -1005,6 +1011,8 @@ pub fn build_microvm(
         mmio_device_manager,
         #[cfg(target_arch = "x86_64")]
         pio_device_manager,
+        #[cfg(target_os = "macos")]
+        intc: intc.clone(),
         #[cfg(target_os = "macos")]
         vm_ctl_tx,
         #[cfg(target_os = "macos")]
@@ -2555,6 +2563,9 @@ fn attach_console_devices(
     let console = Arc::new(Mutex::new(devices::virtio::Console::new(ports).unwrap()));
 
     vmm.exit_observers.push(console.clone());
+
+    #[cfg(target_os = "macos")]
+    vmm.mmio_device_manager.add_snapshottable(console.clone());
 
     event_manager
         .add_subscriber(console.clone())

--- a/src/vmm/src/device_manager/hvf/mmio.rs
+++ b/src/vmm/src/device_manager/hvf/mmio.rs
@@ -120,7 +120,7 @@ impl MMIODeviceManager {
     /// Register an already created MMIO device to be used via MMIO transport.
     pub fn register_mmio_device(
         &mut self,
-        mut mmio_device: devices::virtio::MmioTransport,
+        mmio_device: Arc<Mutex<devices::virtio::MmioTransport>>,
         type_id: u32,
         device_id: String,
     ) -> Result<(u64, u32)> {
@@ -128,10 +128,10 @@ impl MMIODeviceManager {
             return Err(Error::IrqsExhausted);
         }
 
-        mmio_device.set_irq_line(self.irq);
+        mmio_device.lock().unwrap().set_irq_line(self.irq);
 
         self.bus
-            .insert(Arc::new(Mutex::new(mmio_device)), self.mmio_base, MMIO_LEN)
+            .insert(mmio_device, self.mmio_base, MMIO_LEN)
             .map_err(Error::BusError)?;
         let ret = (self.mmio_base, self.irq);
         self.id_to_dev_info.insert(
@@ -360,11 +360,18 @@ mod tests {
             type_id: u32,
             device_id: &str,
         ) -> Result<u64> {
-            let mmio_device =
-                devices::virtio::MmioTransport::new(guest_mem, DummyIrqChip::new().into(), device)
-                    .unwrap();
-            let (mmio_base, _irq) =
-                self.register_mmio_device(mmio_device, type_id, device_id.to_string())?;
+            let mmio_device = devices::virtio::MmioTransport::new(
+                guest_mem,
+                DummyIrqChip::new().into(),
+                device,
+                device_id.to_string(),
+            )
+            .unwrap();
+            let (mmio_base, _irq) = self.register_mmio_device(
+                Arc::new(Mutex::new(mmio_device)),
+                type_id,
+                device_id.to_string(),
+            )?;
             Ok(mmio_base)
         }
     }

--- a/src/vmm/src/device_manager/hvf/mmio.rs
+++ b/src/vmm/src/device_manager/hvf/mmio.rs
@@ -11,7 +11,7 @@ use std::{fmt, io};
 
 use devices::fdt::DeviceInfoForFDT;
 use devices::legacy::IrqChip;
-use devices::{BusDevice, DeviceType};
+use devices::{BusDevice, DeviceType, Snapshottable};
 use kernel::cmdline as kernel_cmdline;
 use polly::event_manager::EventManager;
 #[cfg(target_arch = "aarch64")]
@@ -84,6 +84,9 @@ pub struct MMIODeviceManager {
     irq: u32,
     last_irq: u32,
     id_to_dev_info: HashMap<(DeviceType, String), MMIODeviceInfo>,
+    /// Devices that participate in snapshot, collected as they are registered
+    /// so the VMM can capture their state without downcasting bus entries.
+    snapshottables: Vec<Arc<Mutex<dyn Snapshottable>>>,
 }
 
 impl MMIODeviceManager {
@@ -99,7 +102,19 @@ impl MMIODeviceManager {
             last_irq: irq_interval.1,
             bus: devices::Bus::new(),
             id_to_dev_info: HashMap::new(),
+            snapshottables: Vec::new(),
         }
+    }
+
+    /// Devices to capture in a snapshot, in registration order.
+    pub fn snapshottables(&self) -> &[Arc<Mutex<dyn Snapshottable>>] {
+        &self.snapshottables
+    }
+
+    /// Register a snapshottable device created outside this manager (e.g. a
+    /// virtio device built in the VMM builder).
+    pub fn add_snapshottable(&mut self, dev: Arc<Mutex<dyn Snapshottable>>) {
+        self.snapshottables.push(dev);
     }
 
     /// Register an already created MMIO device to be used via MMIO transport.
@@ -190,8 +205,10 @@ impl MMIODeviceManager {
         let rtc_evt = EventFd::new(utils::eventfd::EFD_NONBLOCK).map_err(Error::EventFd)?;
         let device = devices::legacy::RTC::new(rtc_evt.try_clone().map_err(Error::EventFd)?);
 
+        let device = Arc::new(Mutex::new(device));
+        self.snapshottables.push(device.clone());
         self.bus
-            .insert(Arc::new(Mutex::new(device)), self.mmio_base, MMIO_LEN)
+            .insert(device, self.mmio_base, MMIO_LEN)
             .map_err(Error::BusError)?;
 
         let ret = self.mmio_base;

--- a/src/vmm/src/device_manager/kvm/mmio.rs
+++ b/src/vmm/src/device_manager/kvm/mmio.rs
@@ -127,7 +127,7 @@ impl MMIODeviceManager {
     pub fn register_mmio_device(
         &mut self,
         vm: &VmFd,
-        mut mmio_device: devices::virtio::MmioTransport,
+        mmio_device: Arc<Mutex<devices::virtio::MmioTransport>>,
         type_id: u32,
         device_id: String,
     ) -> Result<(u64, u32)> {
@@ -135,22 +135,25 @@ impl MMIODeviceManager {
             return Err(Error::IrqsExhausted);
         }
 
-        for (i, queue_evt) in mmio_device.queue_evts().iter().enumerate() {
-            let io_addr = IoEventAddress::Mmio(
-                self.mmio_base + u64::from(devices::virtio::NOTIFY_REG_OFFSET),
-            );
+        {
+            let mut dev = mmio_device.lock().unwrap();
+            for (i, queue_evt) in dev.queue_evts().iter().enumerate() {
+                let io_addr = IoEventAddress::Mmio(
+                    self.mmio_base + u64::from(devices::virtio::NOTIFY_REG_OFFSET),
+                );
 
-            vm.register_ioevent(queue_evt, &io_addr, i as u32)
-                .map_err(Error::RegisterIoEvent)?;
+                vm.register_ioevent(queue_evt, &io_addr, i as u32)
+                    .map_err(Error::RegisterIoEvent)?;
+            }
+
+            vm.register_irqfd(dev.interrupt_evt(), self.irq)
+                .map_err(Error::RegisterIrqFd)?;
+
+            dev.set_irq_line(self.irq);
         }
 
-        vm.register_irqfd(mmio_device.interrupt_evt(), self.irq)
-            .map_err(Error::RegisterIrqFd)?;
-
-        mmio_device.set_irq_line(self.irq);
-
         self.bus
-            .insert(Arc::new(Mutex::new(mmio_device)), self.mmio_base, MMIO_LEN)
+            .insert(mmio_device, self.mmio_base, MMIO_LEN)
             .map_err(Error::BusError)?;
         let ret = (self.mmio_base, self.irq);
         self.id_to_dev_info.insert(
@@ -330,7 +333,7 @@ mod tests {
     use devices::virtio::{
         ActivateResult, DeviceQueue, InterruptTransport, QueueConfig, VirtioDevice,
     };
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use utils::errno;
     use vm_memory::{GuestAddress, GuestMemoryMmap};
 
@@ -346,11 +349,19 @@ mod tests {
             type_id: u32,
             device_id: &str,
         ) -> Result<u64> {
-            let mmio_device =
-                devices::virtio::MmioTransport::new(guest_mem, DummyIrqChip::new().into(), device)
-                    .unwrap();
-            let (mmio_base, _irq) =
-                self.register_mmio_device(vm, mmio_device, type_id, device_id.to_string())?;
+            let mmio_device = devices::virtio::MmioTransport::new(
+                guest_mem,
+                DummyIrqChip::new().into(),
+                device,
+                device_id.to_string(),
+            )
+            .unwrap();
+            let (mmio_base, _irq) = self.register_mmio_device(
+                vm,
+                Arc::new(Mutex::new(mmio_device)),
+                type_id,
+                device_id.to_string(),
+            )?;
             #[cfg(target_arch = "x86_64")]
             self.add_device_to_cmdline(_cmdline, mmio_base, _irq)?;
             Ok(mmio_base)

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -428,6 +428,17 @@ impl Vmm {
             };
             writer.section(SectionId::Vcpu, VCPU_SECTION_VERSION, &state.to_bytes());
         }
+        // Quiesce every device first: the vCPUs are frozen but device workers
+        // aren't, and they own the live queue indices. Also stops anything from
+        // writing guest RAM before it's dumped.
+        for dev in self.mmio_device_manager.snapshottables() {
+            let mut dev = dev.lock().unwrap();
+            dev.pause()
+                .map_err(|e| SnapErr::State(format!("device {}: {e:?}", dev.id())))?;
+        }
+
+        // GIC after pause: a worker completing during `pause` raises an IRQ the
+        // blob would otherwise miss, hanging the restored guest.
         let gic = self
             .intc
             .lock()

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -21,6 +21,8 @@ pub mod resources;
 /// Signal handling utilities.
 #[cfg(target_os = "linux")]
 pub mod signal_handler;
+/// VM snapshot/restore seam (M0 skeleton).
+pub mod snapshot;
 /// Wrappers over structures used to configure the VMM.
 pub mod vmm_config;
 
@@ -212,11 +214,15 @@ pub struct Vmm {
     #[cfg(target_arch = "x86_64")]
     pio_device_manager: PortIODeviceManager,
 
-    // Out-of-band live pause/resume requests: the C API sends `VmCtl` from
-    // another thread; the event loop freezes or wakes the vCPUs. A single
-    // channel rather than one eventfd per operation, so the event loop observes
-    // the requests in the order they were made. Device worker threads are
-    // notify-driven, so a frozen guest leaves them idle without explicit
+    // Interrupt controller handle, retained for snapshot capture of GIC state.
+    #[cfg(target_os = "macos")]
+    intc: IrqChip,
+
+    // Out-of-band live pause/resume/snapshot requests: the C API sends `VmCtl`
+    // from another thread; the event loop freezes, wakes or serializes the VM.
+    // A single channel rather than one eventfd per operation, so the event loop
+    // observes the requests in the order they were made. Device worker threads
+    // are notify-driven, so a frozen guest leaves them idle without explicit
     // handling.
     #[cfg(target_os = "macos")]
     vm_ctl_tx: PollableChannelSender<VmCtl>,
@@ -234,6 +240,8 @@ pub struct Vmm {
 pub enum VmCtl {
     Pause,
     Resume,
+    /// Serialize the VM into this directory, then act on the flags.
+    Snapshot(std::path::PathBuf, crate::snapshot::SnapshotFlags),
 }
 
 impl Vmm {
@@ -292,8 +300,8 @@ impl Vmm {
         Ok(())
     }
 
-    /// Sender for live [`VmCtl`] requests. The event loop runs [`Vmm::pause`] /
-    /// [`Vmm::resume`] in response.
+    /// Sender for live [`VmCtl`] requests. The event loop runs [`Vmm::pause`],
+    /// [`Vmm::resume`] or [`Vmm::snapshot`] in response.
     #[cfg(target_os = "macos")]
     pub fn vm_ctl_sender(&self) -> PollableChannelSender<VmCtl> {
         self.vm_ctl_tx.clone()
@@ -348,6 +356,120 @@ impl Vmm {
         }
         self.paused = false;
         Ok(())
+    }
+
+    /// Snapshot the running VM into the directory `path`: vCPU registers, GIC
+    /// state, devices, and guest RAM. The vCPUs are frozen for the duration so
+    /// the captured pieces are mutually consistent. This is the equivalent of
+    /// the proposed 2.0 `RunningVmm::snapshot(path, flags)`.
+    ///
+    /// `flags` selects the post-capture action: `Exit` returns `Ok` (the caller
+    /// terminates the process); `Resume` is not yet implemented.
+    ///
+    /// M1 assumes every configured vCPU is running; a never-powered-on
+    /// secondary would block waiting for its `Snapshotted` response.
+    #[cfg(target_os = "macos")]
+    pub fn snapshot(
+        &mut self,
+        path: &std::path::Path,
+        flags: crate::snapshot::SnapshotFlags,
+    ) -> std::result::Result<(), crate::snapshot::SnapErr> {
+        use crate::snapshot::SnapshotFlags;
+        use crate::snapshot::{
+            Aarch64VcpuState, MANIFEST_VERSION, Manifest, SectionId, SnapErr, VCPU_SECTION_VERSION,
+            VMSTATE_VERSION, VmstateWriter, VtimerState, write_snapshot,
+        };
+        use crate::vstate::{VcpuEvent, VcpuResponse};
+        use vm_memory::{GuestMemory, GuestMemoryRegion};
+
+        // Freeze every vCPU, then ask each parked thread to report its own
+        // registers and ICC state: HVF's per-vCPU `hv_gic_*` calls are
+        // thread-affine, so the coordinator can't read ICC on their behalf.
+        self.pause().map_err(SnapErr::State)?;
+        for h in &self.vcpus_handles {
+            h.send_event(VcpuEvent::Snapshot)
+                .map_err(|e| SnapErr::State(format!("vcpu snapshot event: {e:?}")))?;
+        }
+
+        // Don't hold the GIC lock here: each vCPU thread takes it to read its own
+        // (thread-affine) ICC state while producing the response we await below.
+        let mut writer = VmstateWriter::new();
+        for h in &self.vcpus_handles {
+            let (hvf_state, icc) = match h.response_receiver().recv() {
+                Ok(VcpuResponse::Snapshotted(s, icc)) => (*s, icc),
+                Ok(other) => {
+                    return Err(SnapErr::State(format!(
+                        "unexpected vcpu response: {other:?}"
+                    )));
+                }
+                Err(e) => return Err(SnapErr::State(format!("vcpu response: {e:?}"))),
+            };
+            let state = Aarch64VcpuState {
+                gp: hvf_state
+                    .gp
+                    .try_into()
+                    .map_err(|_| SnapErr::State("gp register count".into()))?,
+                sysregs: hvf_state.sysregs,
+                simd: hvf_state
+                    .simd
+                    .try_into()
+                    .map_err(|_| SnapErr::State("simd register count".into()))?,
+                icc,
+                fpcr: hvf_state.fpcr,
+                fpsr: hvf_state.fpsr,
+                vtimer: VtimerState {
+                    mask: hvf_state.vtimer_mask,
+                    offset: hvf_state.vtimer_offset,
+                },
+                host_counter: hvf_state.host_counter,
+            };
+            writer.section(SectionId::Vcpu, VCPU_SECTION_VERSION, &state.to_bytes());
+        }
+        let gic = self
+            .intc
+            .lock()
+            .unwrap()
+            .save_gic_state()
+            .map_err(|e| SnapErr::State(format!("gic state: {e:?}")))?;
+        writer.section(SectionId::Gic, 1, &gic);
+
+        // Per-device sections: framed as [id_len u16][id][device bytes], with
+        // the device's own version as the section version.
+        for dev in self.mmio_device_manager.snapshottables() {
+            let dev = dev.lock().unwrap();
+            let state = dev
+                .save()
+                .map_err(|e| SnapErr::State(format!("device {}: {e:?}", dev.id())))?;
+            let id = dev.id().as_bytes();
+            let mut payload = Vec::with_capacity(2 + id.len() + state.bytes.len());
+            payload.extend_from_slice(&(id.len() as u16).to_le_bytes());
+            payload.extend_from_slice(id);
+            payload.extend_from_slice(&state.bytes);
+            writer.section(SectionId::Device, state.version, &payload);
+        }
+        let vmstate = writer.finish();
+
+        // Manifest + on-disk layout (guest RAM dumped by write_snapshot).
+        let mem_bytes: u64 = self.guest_memory.iter().map(|r| r.len()).sum();
+        let manifest = Manifest {
+            manifest_version: MANIFEST_VERSION,
+            libkrun_version: env!("CARGO_PKG_VERSION").to_string(),
+            arch: "aarch64".to_string(),
+            backend: "hvf".to_string(),
+            mem_size_mib: (mem_bytes / (1 << 20)) as usize,
+            vcpu_count: self.vcpus_handles.len() as u8,
+            vmstate_version: VMSTATE_VERSION,
+        };
+        write_snapshot(path, &manifest, &vmstate, &self.guest_memory)?;
+
+        match flags {
+            // The vCPUs are frozen; the caller terminates the process.
+            SnapshotFlags::Exit => Ok(()),
+            // Resuming frozen vCPUs (unpark + restore vtimer) is a later step.
+            SnapshotFlags::Resume => Err(SnapErr::State(
+                "snapshot resume is not yet implemented".into(),
+            )),
+        }
     }
 
     /// Configures the system for boot.
@@ -490,12 +612,32 @@ impl Subscriber for Vmm {
         #[cfg(target_os = "macos")]
         if source == self.vm_ctl_rx.as_raw_fd() && event_set == EventSet::IN {
             while let Ok(Some(req)) = self.vm_ctl_rx.try_recv() {
-                let res = match req {
-                    VmCtl::Pause => self.pause(),
-                    VmCtl::Resume => self.resume(),
-                };
-                if let Err(e) = res {
-                    error!("vm {req:?} failed: {e}");
+                match &req {
+                    VmCtl::Pause => {
+                        if let Err(e) = self.pause() {
+                            error!("vm pause failed: {e}");
+                        }
+                    }
+                    VmCtl::Resume => {
+                        if let Err(e) = self.resume() {
+                            error!("vm resume failed: {e}");
+                        }
+                    }
+                    // A snapshot leaves the vCPUs frozen either way, so the
+                    // process ends here whether or not it was written.
+                    VmCtl::Snapshot(path, flags) => {
+                        match self.snapshot(path, *flags) {
+                            Ok(()) => {
+                                info!("snapshot written to {}", path.display());
+                                self.stop(FC_EXIT_CODE_OK as i32);
+                            }
+                            Err(e) => {
+                                error!("snapshot failed: {e:?}");
+                                self.stop(FC_EXIT_CODE_GENERIC_ERROR as i32);
+                            }
+                        }
+                        return;
+                    }
                 }
             }
             return;

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -21,7 +21,10 @@ pub mod resources;
 /// Signal handling utilities.
 #[cfg(target_os = "linux")]
 pub mod signal_handler;
-/// VM snapshot/restore seam (M0 skeleton).
+/// VM snapshot/restore seam. macOS/HVF only — the capture/restore backend and
+/// its serde manifest are HVF-specific, so the module (and serde) stay off other
+/// targets.
+#[cfg(target_os = "macos")]
 pub mod snapshot;
 /// Wrappers over structures used to configure the VMM.
 pub mod vmm_config;
@@ -433,13 +436,18 @@ impl Vmm {
             .map_err(|e| SnapErr::State(format!("gic state: {e:?}")))?;
         writer.section(SectionId::Gic, 1, &gic);
 
-        // Per-device sections: framed as [id_len u16][id][device bytes], with
-        // the device's own version as the section version.
+        // Per-device sections in registration order, framed as
+        // [id_len u16][id][device bytes] with the device's own section version.
+        // Device kind is not unique (two virtio-fs devices are both "fs"), so
+        // restore matches by position; the manifest records the ordered kinds as
+        // the topology the restore config must reproduce.
+        let mut device_kinds = Vec::new();
         for dev in self.mmio_device_manager.snapshottables() {
             let dev = dev.lock().unwrap();
             let state = dev
                 .save()
                 .map_err(|e| SnapErr::State(format!("device {}: {e:?}", dev.id())))?;
+            device_kinds.push(dev.id().to_string());
             let id = dev.id().as_bytes();
             let mut payload = Vec::with_capacity(2 + id.len() + state.bytes.len());
             payload.extend_from_slice(&(id.len() as u16).to_le_bytes());
@@ -459,6 +467,7 @@ impl Vmm {
             mem_size_mib: (mem_bytes / (1 << 20)) as usize,
             vcpu_count: self.vcpus_handles.len() as u8,
             vmstate_version: VMSTATE_VERSION,
+            devices: device_kinds,
         };
         write_snapshot(path, &manifest, &vmstate, &self.guest_memory)?;
 

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -492,6 +492,10 @@ impl Vcpu {
                 self.exit(FC_EXIT_CODE_GENERIC_ERROR);
                 return;
             }
+            // GIC is loaded; the coordinator can now start the device workers.
+            self.response_sender
+                .send(VcpuResponse::Restored)
+                .expect("failed to send Restored status");
         } else {
             let entry_addr = if let Some(boot_receiver) = &self.boot_receiver {
                 boot_receiver.recv().unwrap()
@@ -695,6 +699,9 @@ pub enum VcpuResponse {
     /// Vcpu reported its register state and per-vCPU ICC registers in response
     /// to a `Snapshot` event.
     Snapshotted(Box<HvfVcpuState>, Vec<(u32, u64)>),
+    /// Vcpu finished hydrating snapshot state (GIC included); the coordinator
+    /// waits for this before starting the device workers.
+    Restored,
 }
 
 /// Wrapper over Vcpu that hides the underlying interactions with the Vcpu thread.

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -203,10 +203,26 @@ pub struct Vcpu {
     vcpu_list: Arc<VcpuList>,
     nested_enabled: bool,
 
+    /// Snapshot state to hydrate instead of a normal boot. `None` on a fresh VM.
+    restore: Option<VcpuRestore>,
+
     /// GIC handle, set before capture so this thread can read its own per-vCPU
     /// ICC registers (HVF's `hv_gic_*` per-vCPU calls are thread-affine, so the
-    /// coordinator can't read them on the vCPU's behalf).
+    /// coordinator can't read them on the vCPU's behalf). Also carries the
+    /// restore calls, which are thread-affine for the same reason.
     intc: Option<IrqChip>,
+}
+
+/// State hydrated onto a vCPU on the restore path, replacing its normal boot
+/// (`set_initial_state`). Built by the restore orchestrator in `builder.rs`.
+pub struct VcpuRestore {
+    /// Architectural register file captured at snapshot.
+    pub state: HvfVcpuState,
+    /// Per-vCPU GIC CPU-interface (ICC) registers.
+    pub icc: Vec<(u32, u64)>,
+    /// The global GIC distributor/redistributor blob — `Some` only on the vCPU
+    /// that restores it (once, after every redistributor exists).
+    pub gic: Option<Vec<u8>>,
 }
 
 impl Vcpu {
@@ -300,12 +316,18 @@ impl Vcpu {
             response_sender,
             vcpu_list,
             nested_enabled,
+            restore: None,
             intc: None,
         })
     }
 
-    /// Give this vCPU the GIC handle so it can capture its own ICC state on its
-    /// own thread during a snapshot.
+    /// Hydrate this vCPU from a snapshot instead of booting it normally.
+    pub fn set_restore(&mut self, restore: VcpuRestore) {
+        self.restore = Some(restore);
+    }
+
+    /// Give this vCPU the GIC handle so it can capture or restore its own ICC
+    /// state on its own thread.
     pub fn set_intc(&mut self, intc: IrqChip) {
         self.intc = Some(intc);
     }
@@ -464,15 +486,23 @@ impl Vcpu {
         let (wfe_sender, wfe_receiver) = unbounded();
         self.vcpu_list.register(hvf_vcpuid, wfe_sender);
 
-        let entry_addr = if let Some(boot_receiver) = &self.boot_receiver {
-            boot_receiver.recv().unwrap()
+        if let Some(restore) = self.restore.take() {
+            if let Err(e) = self.apply_restore(&hvf_vcpu, hvf_vcpuid, restore) {
+                error!("vCPU {} restore failed: {e}", self.id);
+                self.exit(FC_EXIT_CODE_GENERIC_ERROR);
+                return;
+            }
         } else {
-            self.boot_entry_addr
-        };
+            let entry_addr = if let Some(boot_receiver) = &self.boot_receiver {
+                boot_receiver.recv().unwrap()
+            } else {
+                self.boot_entry_addr
+            };
 
-        hvf_vcpu
-            .set_initial_state(entry_addr, self.fdt_addr)
-            .unwrap_or_else(|_| panic!("Can't set HVF vCPU {hvf_vcpuid} initial state"));
+            hvf_vcpu
+                .set_initial_state(entry_addr, self.fdt_addr)
+                .unwrap_or_else(|_| panic!("Can't set HVF vCPU {hvf_vcpuid} initial state"));
+        }
 
         loop {
             // An out-of-band pause request breaks the vCPU out of HVF via
@@ -541,6 +571,44 @@ impl Vcpu {
     }
 
     fn wait_for_resume(&mut self) {}
+
+    /// Hydrate snapshot state onto this freshly-created vCPU instead of booting
+    /// it. The GIC blob (if present) is restored first — its redistributor state
+    /// exists now that `HvfVcpu::new` has run — then the register file, then the
+    /// per-vCPU ICC registers (which live in the now-restored CPU interface).
+    ///
+    /// ponytail: single-vCPU happy path. With >1 vCPU the GIC blob must be
+    /// restored once after ALL redistributors exist (a barrier across the vCPU
+    /// threads), and every vCPU must share one vtimer offset (CNTVCT is
+    /// system-wide). Add both when multi-vCPU restore is needed.
+    ///
+    /// Returns an error (not a panic) on malformed snapshot data — the register
+    /// and ICC ids come from an untrusted snapshot and are validated against the
+    /// capture allowlists inside `restore_state` / `restore_vcpu_icc`.
+    fn apply_restore(
+        &self,
+        hvf_vcpu: &HvfVcpu,
+        hvf_id: u64,
+        restore: VcpuRestore,
+    ) -> std::result::Result<(), String> {
+        let intc = self.intc.as_ref().expect("vcpu intc set before restore");
+        if let Some(gic) = &restore.gic {
+            intc.lock()
+                .unwrap()
+                .restore_gic_state(gic)
+                .map_err(|e| format!("GIC state restore: {e:?}"))?;
+        }
+        let offset =
+            hvf::shared_vtimer_offset(restore.state.host_counter, restore.state.vtimer_offset);
+        hvf_vcpu
+            .restore_state(&restore.state, offset)
+            .map_err(|e| format!("vCPU register restore: {e:?}"))?;
+        intc.lock()
+            .unwrap()
+            .restore_vcpu_icc(hvf_id, &restore.icc)
+            .map_err(|e| format!("vCPU ICC restore: {e:?}"))?;
+        Ok(())
+    }
 
     /// Freeze in response to `Pause`, block until `Resume`, and advance the vtimer
     /// offset by the paused ticks (computed once VM-wide) so CNTVCT stays

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -19,8 +19,8 @@ use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 
 use arch::ArchMemoryInfo;
 use crossbeam_channel::{Receiver, Sender, after, select, unbounded};
-use devices::legacy::VcpuList;
-use hvf::{HvfVcpu, HvfVm, VcpuExit, Vcpus};
+use devices::legacy::{IrqChip, VcpuList};
+use hvf::{HvfVcpu, HvfVcpuState, HvfVm, VcpuExit, Vcpus};
 use utils::eventfd::EventFd;
 use vm_memory::{
     Address, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion,
@@ -202,6 +202,11 @@ pub struct Vcpu {
 
     vcpu_list: Arc<VcpuList>,
     nested_enabled: bool,
+
+    /// GIC handle, set before capture so this thread can read its own per-vCPU
+    /// ICC registers (HVF's `hv_gic_*` per-vCPU calls are thread-affine, so the
+    /// coordinator can't read them on the vCPU's behalf).
+    intc: Option<IrqChip>,
 }
 
 impl Vcpu {
@@ -295,7 +300,14 @@ impl Vcpu {
             response_sender,
             vcpu_list,
             nested_enabled,
+            intc: None,
         })
+    }
+
+    /// Give this vCPU the GIC handle so it can capture its own ICC state on its
+    /// own thread during a snapshot.
+    pub fn set_intc(&mut self, intc: IrqChip) {
+        self.intc = Some(intc);
     }
 
     /// Returns the cpu index as seen by the guest OS.
@@ -530,11 +542,10 @@ impl Vcpu {
 
     fn wait_for_resume(&mut self) {}
 
-    /// Freeze this vCPU in response to a `Pause` event and block until `Resume`,
-    /// which carries the paused tick count. Advancing the vtimer offset by it
-    /// keeps the guest's CNTVCT continuous so armed timers don't fire en masse
-    /// to catch up the gap. The coordinator computes the tick count once for the
-    /// whole VM, so multi-vCPU offsets stay in lockstep.
+    /// Freeze in response to `Pause`, block until `Resume`, and advance the vtimer
+    /// offset by the paused ticks (computed once VM-wide) so CNTVCT stays
+    /// continuous. A `Snapshot` event is served while parked — the registers and
+    /// per-vCPU ICC must be read on this thread (HVF's `hv_gic_*` are thread-affine).
     fn pause_and_park(&mut self, hvf_vcpu: &HvfVcpu) {
         self.response_sender
             .send(VcpuResponse::Paused)
@@ -552,7 +563,23 @@ impl Vcpu {
                         .expect("failed to send Resumed status");
                     return;
                 }
-                Ok(_) => {}
+                Ok(VcpuEvent::Snapshot) => {
+                    let state = hvf_vcpu
+                        .save_state()
+                        .unwrap_or_else(|e| panic!("vCPU {} snapshot failed: {e:?}", self.id));
+                    let icc = self
+                        .intc
+                        .as_ref()
+                        .expect("vcpu intc set before snapshot")
+                        .lock()
+                        .unwrap()
+                        .save_vcpu_icc(hvf_vcpu.id())
+                        .unwrap_or_else(|e| panic!("vCPU {} ICC snapshot failed: {e:?}", self.id));
+                    self.response_sender
+                        .send(VcpuResponse::Snapshotted(Box::new(state), icc))
+                        .expect("failed to send snapshot state");
+                }
+                Ok(VcpuEvent::Pause) => {}
                 Err(_) => return,
             }
         }
@@ -584,9 +611,11 @@ pub enum VcpuEvent {
     /// (the wall-clock time the VM spent paused). The coordinator sends the
     /// same value to every vCPU so their counters stay synchronized.
     Resume(u64),
+    /// Report this (already paused) vCPU's register and ICC state.
+    Snapshot,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
 /// List of responses that the Vcpu reports.
 pub enum VcpuResponse {
     /// Vcpu is paused.
@@ -595,6 +624,9 @@ pub enum VcpuResponse {
     Resumed,
     /// Vcpu is stopped.
     Exited(u8),
+    /// Vcpu reported its register state and per-vCPU ICC registers in response
+    /// to a `Snapshot` event.
+    Snapshotted(Box<HvfVcpuState>, Vec<(u32, u64)>),
 }
 
 /// Wrapper over Vcpu that hides the underlying interactions with the Vcpu thread.

--- a/src/vmm/src/snapshot/mod.rs
+++ b/src/vmm/src/snapshot/mod.rs
@@ -1,0 +1,425 @@
+//! VM snapshot format and capture orchestration.
+//!
+//! The shared types here name no hypervisor: KVM and HVF both fill the same
+//! arch-keyed register set, the same opaque GIC/device blobs, and the same
+//! on-disk layout (`manifest.json` + `memory.img` + `vmstate`).
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+#[cfg(target_arch = "aarch64")]
+use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+use vm_memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+
+/// What to do with the guest after a snapshot is captured. Mirrors the typed
+/// `SnapshotFlags` of the proposed 2.0 Rust API (`RunningVmm::snapshot`); the C
+/// shim parses the integer flag into this.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SnapshotFlags {
+    /// Capture, then terminate the process.
+    Exit,
+    /// Capture, then keep the guest running.
+    Resume,
+}
+
+impl SnapshotFlags {
+    /// Parse the C-ABI integer flag. `None` if unknown.
+    pub fn from_bits(bits: u32) -> Option<Self> {
+        match bits {
+            0 => Some(SnapshotFlags::Exit),
+            1 => Some(SnapshotFlags::Resume),
+            _ => None,
+        }
+    }
+}
+
+/// Failure modes for save/restore. Maps to negative errno at the C API edge.
+#[derive(Debug)]
+pub enum SnapErr {
+    /// Underlying I/O on the snapshot files.
+    Io(std::io::Error),
+    /// `manifest`/`vmstate` version the loader cannot handle. Never half-loads.
+    Version { expected: u32, found: u32 },
+    /// A device or vCPU rejected the state it was handed.
+    State(String),
+}
+
+impl From<std::io::Error> for SnapErr {
+    fn from(e: std::io::Error) -> Self {
+        SnapErr::Io(e)
+    }
+}
+
+// Per-device state and the `Snapshottable` trait live in the devices crate
+// (devices can't depend on the VMM). Re-exported here so the snapshot format
+// and orchestration can refer to them in one place.
+pub use devices::snapshot::{DeviceState, Snapshottable};
+
+/// aarch64 capture set (mirrors the registers a true PC-resume needs).
+#[cfg(target_arch = "aarch64")]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct Aarch64VcpuState {
+    /// X0..X30, PC, CPSR.
+    pub gp: [u64; 33],
+    /// (sys_reg id, value) — incl. pointer-auth keys, or `autiasp` faults on resume.
+    pub sysregs: Vec<(u32, u64)>,
+    /// Q0..Q31 NEON/FP.
+    pub simd: [u128; 32],
+    /// Per-vCPU GIC CPU-interface (ICC) regs.
+    pub icc: Vec<(u32, u64)>,
+    /// FP control / status.
+    pub fpcr: u64,
+    pub fpsr: u64,
+    /// Virtual timer mask + offset (offset recomputed on restore for CNTVCT continuity).
+    pub vtimer: VtimerState,
+    /// `mach_absolute_time()` at capture — the vtimer-continuity anchor.
+    pub host_counter: u64,
+}
+
+#[cfg(target_arch = "aarch64")]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct VtimerState {
+    pub mask: bool,
+    pub offset: u64,
+}
+
+/// Version byte for the per-vCPU `vmstate` section.
+#[cfg(target_arch = "aarch64")]
+pub const VCPU_SECTION_VERSION: u8 = 1;
+
+#[cfg(target_arch = "aarch64")]
+impl Aarch64VcpuState {
+    /// Pack into the vCPU section bytes via bincode.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bincode::encode_to_vec(self, bincode::config::standard())
+            .expect("vcpu state encode is infallible for an in-memory buffer")
+    }
+
+    /// Inverse of [`Aarch64VcpuState::to_bytes`].
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SnapErr> {
+        let (state, _) = bincode::decode_from_slice(bytes, bincode::config::standard())
+            .map_err(|e| SnapErr::State(format!("vcpu state: {e}")))?;
+        Ok(state)
+    }
+}
+
+/// Serialize guest RAM to the snapshot's `memory.img`. Restore is
+/// construction-time (a `MAP_PRIVATE` mapping of the image), so only capture is
+/// a function here.
+pub fn write_mem_image(mem: &GuestMemoryMmap, out: &mut dyn Write) -> Result<(), SnapErr> {
+    for region in mem.iter() {
+        let host = mem
+            .get_host_address(region.start_addr())
+            .map_err(|e| SnapErr::State(format!("guest memory host address: {e:?}")))?;
+        // SAFETY: vCPUs are stopped at capture, so the region is quiescent and
+        // the mapping outlives this read. Regions are written in address order.
+        let bytes = unsafe { std::slice::from_raw_parts(host, region.len() as usize) };
+        out.write_all(bytes)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// snapshot directory: manifest.json + vmstate + memory.img
+// ---------------------------------------------------------------------------
+
+/// Snapshot file names within the snapshot directory.
+pub const MANIFEST_NAME: &str = "manifest.json";
+pub const VMSTATE_NAME: &str = "vmstate";
+pub const MEMORY_NAME: &str = "memory.img";
+
+/// Current manifest schema version. Independent of [`VMSTATE_VERSION`].
+pub const MANIFEST_VERSION: u32 = 1;
+
+/// The human-readable side of a snapshot: what's needed to rebuild the VM
+/// shape before loading `vmstate`/`memory.img`. Device descriptors are added
+/// with per-device capture.
+#[derive(Serialize, Deserialize)]
+pub struct Manifest {
+    pub manifest_version: u32,
+    pub libkrun_version: String,
+    pub arch: String,
+    pub backend: String,
+    pub mem_size_mib: usize,
+    pub vcpu_count: u8,
+    pub vmstate_version: u32,
+}
+
+/// Write a complete snapshot directory: `manifest.json`, the `vmstate` blob,
+/// and `memory.img` (the guest RAM dump). Creates `dir` if needed.
+pub fn write_snapshot(
+    dir: &Path,
+    manifest: &Manifest,
+    vmstate: &[u8],
+    mem: &GuestMemoryMmap,
+) -> Result<(), SnapErr> {
+    fs::create_dir_all(dir)?;
+    let json = serde_json::to_vec_pretty(manifest).map_err(|e| SnapErr::State(e.to_string()))?;
+    fs::write(dir.join(MANIFEST_NAME), json)?;
+    fs::write(dir.join(VMSTATE_NAME), vmstate)?;
+    let mut img = fs::File::create(dir.join(MEMORY_NAME))?;
+    write_mem_image(mem, &mut img)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// vmstate binary framing
+//
+// Magic + version header, then length-prefixed sections. Hand-rolled (not serde)
+// because it's a register/queue dump, not config. Each section carries its own
+// version byte, so a device's schema can bump without bumping the whole blob.
+// ---------------------------------------------------------------------------
+
+/// `vmstate` blob magic. Bumps only on an incompatible framing change.
+pub const VMSTATE_MAGIC: &[u8; 4] = b"KRSV";
+/// Framing version (the header layout), independent of any section's version.
+pub const VMSTATE_VERSION: u32 = 1;
+
+/// Section tags. The byte values are part of the on-disk format — append only.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u8)]
+pub enum SectionId {
+    Vcpu = 0,
+    Gic = 1,
+    Device = 2,
+}
+
+/// Appends magic + version + length-prefixed sections into an in-memory blob.
+pub struct VmstateWriter {
+    buf: Vec<u8>,
+}
+
+impl Default for VmstateWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VmstateWriter {
+    pub fn new() -> Self {
+        let mut buf = Vec::with_capacity(8);
+        buf.extend_from_slice(VMSTATE_MAGIC);
+        buf.extend_from_slice(&VMSTATE_VERSION.to_le_bytes());
+        Self { buf }
+    }
+
+    /// One section: `[id:u8][version:u8][len:u32 LE][bytes]`.
+    pub fn section(&mut self, id: SectionId, version: u8, bytes: &[u8]) {
+        self.buf.push(id as u8);
+        self.buf.push(version);
+        self.buf
+            .extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+        self.buf.extend_from_slice(bytes);
+    }
+
+    pub fn finish(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+/// One decoded section, borrowed from the underlying blob.
+pub struct Section<'a> {
+    pub id: u8,
+    pub version: u8,
+    pub bytes: &'a [u8],
+}
+
+/// Validates the header and iterates sections. Never half-reads: a truncated
+/// section yields an error, not a partial value.
+pub struct VmstateReader<'a> {
+    rest: &'a [u8],
+}
+
+impl<'a> VmstateReader<'a> {
+    pub fn new(data: &'a [u8]) -> Result<Self, SnapErr> {
+        if data.len() < 8 || &data[0..4] != VMSTATE_MAGIC {
+            return Err(SnapErr::State("vmstate: bad magic".into()));
+        }
+        let found = u32::from_le_bytes(data[4..8].try_into().unwrap());
+        if found != VMSTATE_VERSION {
+            return Err(SnapErr::Version {
+                expected: VMSTATE_VERSION,
+                found,
+            });
+        }
+        Ok(Self { rest: &data[8..] })
+    }
+}
+
+impl<'a> Iterator for VmstateReader<'a> {
+    type Item = Result<Section<'a>, SnapErr>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.rest.is_empty() {
+            return None;
+        }
+        if self.rest.len() < 6 {
+            return Some(Err(SnapErr::State(
+                "vmstate: truncated section header".into(),
+            )));
+        }
+        let id = self.rest[0];
+        let version = self.rest[1];
+        let len = u32::from_le_bytes(self.rest[2..6].try_into().unwrap()) as usize;
+        let end = 6 + len;
+        if self.rest.len() < end {
+            return Some(Err(SnapErr::State(
+                "vmstate: truncated section body".into(),
+            )));
+        }
+        let bytes = &self.rest[6..end];
+        self.rest = &self.rest[end..];
+        Some(Ok(Section { id, version, bytes }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vmstate_round_trips() {
+        let mut w = VmstateWriter::new();
+        w.section(SectionId::Vcpu, 1, &[1, 2, 3]);
+        w.section(SectionId::Device, 7, b"blk0-state");
+        let blob = w.finish();
+
+        let secs: Vec<_> = VmstateReader::new(&blob)
+            .unwrap()
+            .map(|s| s.unwrap())
+            .collect();
+        assert_eq!(secs.len(), 2);
+        assert_eq!(secs[0].id, SectionId::Vcpu as u8);
+        assert_eq!(secs[0].version, 1);
+        assert_eq!(secs[0].bytes, &[1, 2, 3]);
+        assert_eq!(secs[1].id, SectionId::Device as u8);
+        assert_eq!(secs[1].version, 7);
+        assert_eq!(secs[1].bytes, b"blk0-state");
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        assert!(matches!(
+            VmstateReader::new(b"XXXX\x01\x00\x00\x00"),
+            Err(SnapErr::State(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_version_mismatch() {
+        let mut blob = Vec::new();
+        blob.extend_from_slice(VMSTATE_MAGIC);
+        blob.extend_from_slice(&99u32.to_le_bytes());
+        assert!(matches!(
+            VmstateReader::new(&blob),
+            Err(SnapErr::Version { found: 99, .. })
+        ));
+    }
+
+    #[test]
+    fn writes_snapshot_directory() {
+        use vm_memory::GuestAddress;
+
+        let dir = std::env::temp_dir().join(format!("krun-snap-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+
+        let manifest = Manifest {
+            manifest_version: MANIFEST_VERSION,
+            libkrun_version: "1.18.0".into(),
+            arch: "aarch64".into(),
+            backend: "hvf".into(),
+            mem_size_mib: 1,
+            vcpu_count: 2,
+            vmstate_version: VMSTATE_VERSION,
+        };
+        let mut w = VmstateWriter::new();
+        w.section(SectionId::Vcpu, 1, &[9, 9]);
+        let vmstate = w.finish();
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
+
+        write_snapshot(&dir, &manifest, &vmstate, &mem).unwrap();
+
+        let json = fs::read_to_string(dir.join(MANIFEST_NAME)).unwrap();
+        assert!(json.contains("\"arch\": \"aarch64\""));
+        assert!(json.contains("\"vcpu_count\": 2"));
+        assert_eq!(fs::read(dir.join(VMSTATE_NAME)).unwrap(), vmstate);
+        assert_eq!(fs::metadata(dir.join(MEMORY_NAME)).unwrap().len(), 0x1000);
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn vcpu_state_round_trips() {
+        let state = Aarch64VcpuState {
+            gp: core::array::from_fn(|i| i as u64 * 7 + 1),
+            sysregs: vec![(0xAAAA, 0x1111), (0xBBBB, 0x2222)],
+            simd: core::array::from_fn(|i| (i as u128) << 64 | 0xDEAD),
+            icc: vec![(0xC, 0x3)],
+            fpcr: 0x55,
+            fpsr: 0x66,
+            vtimer: VtimerState {
+                mask: true,
+                offset: 0x1234_5678_9abc,
+            },
+            host_counter: 0xfeed_face,
+        };
+        let bytes = state.to_bytes();
+        assert_eq!(Aarch64VcpuState::from_bytes(&bytes).unwrap(), state);
+        // A truncated blob errors rather than panicking.
+        assert!(Aarch64VcpuState::from_bytes(&bytes[..bytes.len() - 1]).is_err());
+    }
+
+    #[test]
+    fn manifest_round_trips() {
+        let m = Manifest {
+            manifest_version: MANIFEST_VERSION,
+            libkrun_version: "1.0\"evil".into(),
+            arch: "aarch64".into(),
+            backend: "hvf".into(),
+            mem_size_mib: 1,
+            vcpu_count: 1,
+            vmstate_version: VMSTATE_VERSION,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let back: Manifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.libkrun_version, "1.0\"evil");
+        assert_eq!(back.vcpu_count, 1);
+    }
+
+    #[test]
+    fn mem_image_writes_regions_in_order() {
+        use vm_memory::{Bytes, GuestAddress};
+
+        // Two regions; write a distinct pattern into each, then dump.
+        let mem = GuestMemoryMmap::from_ranges(&[
+            (GuestAddress(0), 0x1000),
+            (GuestAddress(0x1000), 0x1000),
+        ])
+        .unwrap();
+        mem.write_slice(&[0xAA; 0x1000], GuestAddress(0)).unwrap();
+        mem.write_slice(&[0xBB; 0x1000], GuestAddress(0x1000))
+            .unwrap();
+
+        let mut out = Vec::new();
+        write_mem_image(&mem, &mut out).unwrap();
+
+        assert_eq!(out.len(), 0x2000);
+        assert!(out[..0x1000].iter().all(|&b| b == 0xAA));
+        assert!(out[0x1000..].iter().all(|&b| b == 0xBB));
+    }
+
+    #[test]
+    fn detects_truncated_body() {
+        let mut blob = Vec::new();
+        blob.extend_from_slice(VMSTATE_MAGIC);
+        blob.extend_from_slice(&VMSTATE_VERSION.to_le_bytes());
+        blob.extend_from_slice(&[SectionId::Vcpu as u8, 1, 10, 0, 0, 0]); // claims 10 bytes
+        blob.extend_from_slice(&[0, 0]); // only 2 present
+        let mut r = VmstateReader::new(&blob).unwrap();
+        assert!(matches!(r.next(), Some(Err(SnapErr::State(_)))));
+    }
+}

--- a/src/vmm/src/snapshot/mod.rs
+++ b/src/vmm/src/snapshot/mod.rs
@@ -5,7 +5,7 @@
 //! on-disk layout (`manifest.json` + `memory.img` + `vmstate`).
 
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::Path;
 
 #[cfg(target_arch = "aarch64")]
@@ -122,6 +122,25 @@ pub fn write_mem_image(mem: &GuestMemoryMmap, out: &mut dyn Write) -> Result<(),
     Ok(())
 }
 
+/// Load `memory.img` back into guest RAM (the inverse of [`write_mem_image`]).
+/// Regions are filled in the same address order they were dumped.
+///
+/// ponytail: copies the image into anonymous guest RAM. A `MAP_PRIVATE` mapping
+/// of `memory.img` would demand-page instead (lower idle RSS) — the upgrade path
+/// if restore RSS matters.
+pub fn load_mem_image(mem: &GuestMemoryMmap, src: &mut dyn Read) -> Result<(), SnapErr> {
+    for region in mem.iter() {
+        let host = mem
+            .get_host_address(region.start_addr())
+            .map_err(|e| SnapErr::State(format!("guest memory host address: {e:?}")))?;
+        // SAFETY: vCPUs are not started yet, so the region is exclusively ours
+        // and the mapping outlives this write.
+        let bytes = unsafe { std::slice::from_raw_parts_mut(host, region.len() as usize) };
+        src.read_exact(bytes)?;
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // snapshot directory: manifest.json + vmstate + memory.img
 // ---------------------------------------------------------------------------
@@ -135,8 +154,7 @@ pub const MEMORY_NAME: &str = "memory.img";
 pub const MANIFEST_VERSION: u32 = 1;
 
 /// The human-readable side of a snapshot: what's needed to rebuild the VM
-/// shape before loading `vmstate`/`memory.img`. Device descriptors are added
-/// with per-device capture.
+/// shape before loading `vmstate`/`memory.img`.
 #[derive(Serialize, Deserialize)]
 pub struct Manifest {
     pub manifest_version: u32,
@@ -146,6 +164,64 @@ pub struct Manifest {
     pub mem_size_mib: usize,
     pub vcpu_count: u8,
     pub vmstate_version: u32,
+    /// Device kinds in registration order. Restore matches saved device state to
+    /// live devices by position, so this is the topology the restore config must
+    /// reproduce exactly (device kind is not unique on its own).
+    pub devices: Vec<String>,
+}
+
+impl Manifest {
+    /// Reject a freshly-configured VM that doesn't match the snapshot it is
+    /// restoring into. Config-validate restore: the embedder rebuilt the VM
+    /// shape (with fresh fds), and this is the single gate before saved state is
+    /// hydrated onto it.
+    pub fn validate(
+        &self,
+        arch: &str,
+        backend: &str,
+        mem_size_mib: usize,
+        vcpu_count: u8,
+        device_kinds: &[&str],
+    ) -> Result<(), SnapErr> {
+        if self.manifest_version != MANIFEST_VERSION {
+            return Err(SnapErr::Version {
+                expected: MANIFEST_VERSION,
+                found: self.manifest_version,
+            });
+        }
+        let mismatch = |field: &str, want: &dyn std::fmt::Display, got: &dyn std::fmt::Display| {
+            SnapErr::State(format!(
+                "snapshot {field} mismatch: snapshot={want}, config={got}"
+            ))
+        };
+        if self.arch != arch {
+            return Err(mismatch("arch", &self.arch, &arch));
+        }
+        if self.backend != backend {
+            return Err(mismatch("backend", &self.backend, &backend));
+        }
+        if self.mem_size_mib != mem_size_mib {
+            return Err(mismatch("mem_size_mib", &self.mem_size_mib, &mem_size_mib));
+        }
+        if self.vcpu_count != vcpu_count {
+            return Err(mismatch("vcpu_count", &self.vcpu_count, &vcpu_count));
+        }
+        if self.devices.len() != device_kinds.len()
+            || self.devices.iter().zip(device_kinds).any(|(a, b)| a != b)
+        {
+            return Err(SnapErr::State(format!(
+                "snapshot device topology mismatch: snapshot={:?}, config={:?}",
+                self.devices, device_kinds
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Read and parse `manifest.json` from a snapshot directory.
+pub fn read_manifest(dir: &Path) -> Result<Manifest, SnapErr> {
+    let bytes = fs::read(dir.join(MANIFEST_NAME))?;
+    serde_json::from_slice(&bytes).map_err(|e| SnapErr::State(format!("manifest: {e}")))
 }
 
 /// Write a complete snapshot directory: `manifest.json`, the `vmstate` blob,
@@ -276,6 +352,94 @@ impl<'a> Iterator for VmstateReader<'a> {
     }
 }
 
+/// Everything the `vmstate` blob carries, decoded for restore. The memory image
+/// and manifest load separately (the caller owns the guest-RAM lifetime).
+#[cfg(target_arch = "aarch64")]
+pub struct Vmstate {
+    /// One per vCPU, in capture (vCPU index) order.
+    pub vcpus: Vec<Aarch64VcpuState>,
+    /// Opaque GIC distributor/redistributor blob.
+    pub gic: Vec<u8>,
+    /// `(device id, state)` pairs; restore binds each onto the live device of
+    /// the same id.
+    pub devices: Vec<(String, DeviceState)>,
+}
+
+/// Decode a `vmstate` blob produced by [`VmstateWriter`] back into its sections.
+#[cfg(target_arch = "aarch64")]
+pub fn load_vmstate(blob: &[u8]) -> Result<Vmstate, SnapErr> {
+    let mut vcpus = Vec::new();
+    let mut gic = Vec::new();
+    let mut devices = Vec::new();
+    for section in VmstateReader::new(blob)? {
+        let s = section?;
+        match s.id {
+            x if x == SectionId::Vcpu as u8 => vcpus.push(Aarch64VcpuState::from_bytes(s.bytes)?),
+            x if x == SectionId::Gic as u8 => gic = s.bytes.to_vec(),
+            x if x == SectionId::Device as u8 => {
+                let (id, bytes) = split_device_section(s.bytes)?;
+                devices.push((
+                    id,
+                    DeviceState {
+                        version: s.version,
+                        bytes,
+                    },
+                ));
+            }
+            other => {
+                return Err(SnapErr::State(format!(
+                    "vmstate: unknown section id {other}"
+                )));
+            }
+        }
+    }
+    Ok(Vmstate {
+        vcpus,
+        gic,
+        devices,
+    })
+}
+
+/// Split a device section's `[id_len u16][id][bytes]` framing (the inverse of
+/// the framing [`crate::Vmm::snapshot`] writes).
+#[cfg(target_arch = "aarch64")]
+fn split_device_section(bytes: &[u8]) -> Result<(String, Vec<u8>), SnapErr> {
+    let id_len = bytes
+        .get(0..2)
+        .map(|b| u16::from_le_bytes(b.try_into().unwrap()) as usize)
+        .ok_or_else(|| SnapErr::State("device section: truncated id length".into()))?;
+    let end = 2 + id_len;
+    let id = bytes
+        .get(2..end)
+        .ok_or_else(|| SnapErr::State("device section: truncated id".into()))?;
+    let id = String::from_utf8(id.to_vec())
+        .map_err(|e| SnapErr::State(format!("device id utf8: {e}")))?;
+    Ok((id, bytes[end..].to_vec()))
+}
+
+/// A snapshot loaded from disk, ready to hydrate onto a freshly-built VM. The
+/// memory image is opened lazily at apply time (it can be large).
+#[cfg(target_arch = "aarch64")]
+pub struct RestoreInput {
+    pub manifest: Manifest,
+    pub vmstate: Vmstate,
+    pub mem_path: std::path::PathBuf,
+}
+
+#[cfg(target_arch = "aarch64")]
+impl RestoreInput {
+    /// Read `manifest.json` + `vmstate` from a snapshot directory.
+    pub fn read(dir: &Path) -> Result<Self, SnapErr> {
+        let manifest = read_manifest(dir)?;
+        let vmstate = load_vmstate(&fs::read(dir.join(VMSTATE_NAME))?)?;
+        Ok(Self {
+            manifest,
+            vmstate,
+            mem_path: dir.join(MEMORY_NAME),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -334,6 +498,7 @@ mod tests {
             mem_size_mib: 1,
             vcpu_count: 2,
             vmstate_version: VMSTATE_VERSION,
+            devices: vec![],
         };
         let mut w = VmstateWriter::new();
         w.section(SectionId::Vcpu, 1, &[9, 9]);
@@ -373,6 +538,76 @@ mod tests {
         assert!(Aarch64VcpuState::from_bytes(&bytes[..bytes.len() - 1]).is_err());
     }
 
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn load_vmstate_splits_sections() {
+        let vcpu = Aarch64VcpuState {
+            gp: core::array::from_fn(|i| i as u64),
+            sysregs: vec![(1, 2)],
+            simd: [0; 32],
+            icc: vec![],
+            fpcr: 0,
+            fpsr: 0,
+            vtimer: VtimerState {
+                mask: false,
+                offset: 0,
+            },
+            host_counter: 42,
+        };
+        let mut w = VmstateWriter::new();
+        w.section(SectionId::Vcpu, VCPU_SECTION_VERSION, &vcpu.to_bytes());
+        w.section(SectionId::Gic, 1, b"gicblob");
+        // Device framing: [id_len u16][id][bytes], section version = dev version.
+        let id = b"rtc0";
+        let mut payload = (id.len() as u16).to_le_bytes().to_vec();
+        payload.extend_from_slice(id);
+        payload.extend_from_slice(b"rtcstate");
+        w.section(SectionId::Device, 2, &payload);
+
+        let vm = load_vmstate(&w.finish()).unwrap();
+        assert_eq!(vm.vcpus.len(), 1);
+        assert_eq!(vm.vcpus[0], vcpu);
+        assert_eq!(vm.gic, b"gicblob");
+        assert_eq!(vm.devices.len(), 1);
+        assert_eq!(vm.devices[0].0, "rtc0");
+        assert_eq!(vm.devices[0].1.version, 2);
+        assert_eq!(vm.devices[0].1.bytes, b"rtcstate");
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn manifest_validate_rejects_mismatch() {
+        let m = Manifest {
+            manifest_version: MANIFEST_VERSION,
+            libkrun_version: "x".into(),
+            arch: "aarch64".into(),
+            backend: "hvf".into(),
+            mem_size_mib: 512,
+            vcpu_count: 1,
+            vmstate_version: VMSTATE_VERSION,
+            devices: vec!["fs".into(), "console".into()],
+        };
+        let devs = ["fs", "console"];
+        assert!(m.validate("aarch64", "hvf", 512, 1, &devs).is_ok());
+        assert!(m.validate("aarch64", "hvf", 256, 1, &devs).is_err());
+        assert!(m.validate("aarch64", "hvf", 512, 2, &devs).is_err());
+        assert!(m.validate("x86_64", "hvf", 512, 1, &devs).is_err());
+        // Topology: reordered, missing, extra, and wrong-kind all fail.
+        assert!(
+            m.validate("aarch64", "hvf", 512, 1, &["console", "fs"])
+                .is_err()
+        );
+        assert!(m.validate("aarch64", "hvf", 512, 1, &["fs"]).is_err());
+        assert!(
+            m.validate("aarch64", "hvf", 512, 1, &["fs", "console", "block"])
+                .is_err()
+        );
+        assert!(
+            m.validate("aarch64", "hvf", 512, 1, &["fs", "block"])
+                .is_err()
+        );
+    }
+
     #[test]
     fn manifest_round_trips() {
         let m = Manifest {
@@ -383,11 +618,13 @@ mod tests {
             mem_size_mib: 1,
             vcpu_count: 1,
             vmstate_version: VMSTATE_VERSION,
+            devices: vec!["fs".into(), "console".into()],
         };
         let json = serde_json::to_string(&m).unwrap();
         let back: Manifest = serde_json::from_str(&json).unwrap();
         assert_eq!(back.libkrun_version, "1.0\"evil");
         assert_eq!(back.vcpu_count, 1);
+        assert_eq!(back.devices, ["fs", "console"]);
     }
 
     #[test]

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -1,7 +1,9 @@
 mod test_vm_config;
 use test_vm_config::TestVmConfig;
 
+mod test_snapshot;
 mod test_vm_pause;
+use test_snapshot::TestSnapshot;
 use test_vm_pause::TestVmPause;
 
 #[cfg(any(feature = "host", target_os = "linux"))]
@@ -96,6 +98,7 @@ pub fn test_cases() -> Vec<TestCase> {
             }),
         ),
         TestCase::new("vm-pause", Box::new(TestVmPause)),
+        TestCase::new("snapshot-create", Box::new(TestSnapshot { ram_mib: 512 })),
         #[cfg(any(feature = "host", target_os = "linux"))]
         TestCase::new("vsock-guest-connect", Box::new(TestVsockGuestConnect)),
         TestCase::new(

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -3,7 +3,7 @@ use test_vm_config::TestVmConfig;
 
 mod test_snapshot;
 mod test_vm_pause;
-use test_snapshot::TestSnapshot;
+use test_snapshot::{TestSnapshot, TestSnapshotResume};
 use test_vm_pause::TestVmPause;
 
 #[cfg(any(feature = "host", target_os = "linux"))]
@@ -99,6 +99,10 @@ pub fn test_cases() -> Vec<TestCase> {
         ),
         TestCase::new("vm-pause", Box::new(TestVmPause)),
         TestCase::new("snapshot-create", Box::new(TestSnapshot { ram_mib: 512 })),
+        TestCase::new(
+            "snapshot-resume",
+            Box::new(TestSnapshotResume { ram_mib: 512 }),
+        ),
         #[cfg(any(feature = "host", target_os = "linux"))]
         TestCase::new("vsock-guest-connect", Box::new(TestVsockGuestConnect)),
         TestCase::new(

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -3,7 +3,7 @@ use test_vm_config::TestVmConfig;
 
 mod test_snapshot;
 mod test_vm_pause;
-use test_snapshot::{TestSnapshot, TestSnapshotResume};
+use test_snapshot::{TestSnapshot, TestSnapshotFsCapture, TestSnapshotResume};
 use test_vm_pause::TestVmPause;
 
 #[cfg(any(feature = "host", target_os = "linux"))]
@@ -102,6 +102,10 @@ pub fn test_cases() -> Vec<TestCase> {
         TestCase::new(
             "snapshot-resume",
             Box::new(TestSnapshotResume { ram_mib: 512 }),
+        ),
+        TestCase::new(
+            "snapshot-fs-capture",
+            Box::new(TestSnapshotFsCapture { ram_mib: 512 }),
         ),
         #[cfg(any(feature = "host", target_os = "linux"))]
         TestCase::new("vsock-guest-connect", Box::new(TestVsockGuestConnect)),

--- a/tests/test_cases/src/test_snapshot.rs
+++ b/tests/test_cases/src/test_snapshot.rs
@@ -6,6 +6,11 @@
 //!   onto a fresh, identically-shaped VM and checks the resumed guest keeps
 //!   running: it resumes mid heartbeat-loop, so its stdout carries the tail of
 //!   the loop but never restarts at `HEARTBEAT 0` the way a fresh boot would.
+//! - `snapshot-fs-capture` snapshots while the guest is hammering virtio-fs, so
+//!   the fs worker is genuinely busy when it is quiesced — the join-at-a-
+//!   descriptor-boundary path the idle tests never exercise. It checks capture
+//!   only: virtio-fs internal fid state is not yet restored, so resuming a guest
+//!   that did fs I/O is a known gap (see the README limitations).
 
 use macros::{guest, host};
 
@@ -17,6 +22,14 @@ pub struct TestSnapshot {
 
 #[cfg_attr(not(feature = "host"), allow(dead_code))]
 pub struct TestSnapshotResume {
+    pub(crate) ram_mib: u32,
+}
+
+/// Snapshots while the guest hammers virtio-fs, so the fs worker is genuinely
+/// busy when it is quiesced. Capture only — restoring a guest that did fs I/O
+/// needs virtio-fs fid state that is not captured yet.
+#[cfg_attr(not(feature = "host"), allow(dead_code))]
+pub struct TestSnapshotFsCapture {
     pub(crate) ram_mib: u32,
 }
 
@@ -158,6 +171,80 @@ mod host {
         }
     }
 
+    /// Capture in a child process, then restore onto a fresh, identically-shaped
+    /// VM and run it. Shared by the plain and I/O resume tests, which differ only
+    /// in the guest workload (dispatched by `test_case`).
+    ///
+    /// A child re-exec captures the snapshot first — HVF allows one VM per
+    /// process, so the child fully exits before the restore VM is built. Its
+    /// console goes to a separate file so the runner's captured stdout is exactly
+    /// the restored guest's output.
+    fn resume_flow(test_setup: &TestSetup, ram_mib: u32) -> anyhow::Result<()> {
+        let root_dir = setup_rootfs(test_setup)?;
+        let snapshot_dir = test_setup.tmp_dir.join("snapshot");
+
+        if std::env::var_os("KRUN_TEST_SNAPSHOT_CREATE").is_some() {
+            let ctx = unsafe { krun_call_u32!(krun_create_ctx())? };
+            return unsafe {
+                capture(
+                    ctx,
+                    ram_mib,
+                    &root_dir,
+                    &test_setup.test_case,
+                    &snapshot_dir,
+                )
+            };
+        }
+
+        let child_stdout = std::fs::File::create(test_setup.tmp_dir.join("create_stdout.txt"))?;
+        let status = Command::new(std::env::current_exe()?)
+            .arg("start-vm")
+            .arg("--test-case")
+            .arg(&test_setup.test_case)
+            .arg("--tmp-dir")
+            .arg(&test_setup.tmp_dir)
+            .env("KRUN_TEST_SNAPSHOT_CREATE", "1")
+            .stdin(Stdio::null())
+            .stdout(child_stdout)
+            .stderr(Stdio::inherit())
+            .status()?;
+        if !snapshot_dir.join("vmstate").exists() {
+            anyhow::bail!("child did not create a snapshot (exit {status:?})");
+        }
+
+        let ctx = unsafe { krun_call_u32!(krun_create_ctx())? };
+        unsafe { configure_vm(ctx, ram_mib, &root_dir, &test_setup.test_case)? };
+        let snapshot_cstr = CString::new(snapshot_dir.as_os_str().as_bytes())?;
+        let rc = unsafe { krun_restore(ctx, snapshot_cstr.as_ptr(), 0) };
+        if rc < 0 {
+            anyhow::bail!("krun_restore failed: {rc}");
+        }
+        Ok(())
+    }
+
+    /// The restored guest must have resumed mid-loop (not rebooted) and run to
+    /// completion. Every workload prints `HEARTBEAT 0..80`, so a fresh reboot
+    /// would show `HEARTBEAT 0` and a hang would never reach `HEARTBEAT 79`.
+    fn check_resumed(stdout: &[u8]) -> TestOutcome {
+        let out = String::from_utf8_lossy(stdout);
+        if !out.contains("HEARTBEAT") {
+            return TestOutcome::Fail(format!(
+                "restored guest produced no heartbeat; stdout: {out:?}"
+            ));
+        }
+        if out.lines().any(|l| l.trim() == "HEARTBEAT 0") {
+            return TestOutcome::Fail(format!(
+                "restored guest restarted the loop (HEARTBEAT 0 present) instead of resuming; stdout: {out:?}"
+            ));
+        }
+        if !out.contains("HEARTBEAT 79") {
+            return TestOutcome::Fail(format!(
+                "restored guest did not finish the heartbeat loop; stdout: {out:?}"
+            ));
+        }
+        TestOutcome::Pass
+    }
+
     impl Test for TestSnapshotResume {
         fn should_run(&self) -> ShouldRun {
             if cfg!(target_os = "macos") {
@@ -172,78 +259,46 @@ mod host {
         }
 
         fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
-            let root_dir = setup_rootfs(&test_setup)?;
-            let snapshot_dir = test_setup.tmp_dir.join("snapshot");
-
-            // A child process (re-exec of this binary with the same test case)
-            // captures the snapshot first; HVF allows one VM per process, so the
-            // child fully exits before we build the restore VM here. Its guest
-            // console goes to a separate file so the stdout the runner captures
-            // is exactly the restored guest's output.
-            if std::env::var_os("KRUN_TEST_SNAPSHOT_CREATE").is_some() {
-                let ctx = unsafe { krun_call_u32!(krun_create_ctx())? };
-                return unsafe {
-                    capture(
-                        ctx,
-                        self.ram_mib,
-                        &root_dir,
-                        &test_setup.test_case,
-                        &snapshot_dir,
-                    )
-                };
-            }
-
-            let child_stdout = std::fs::File::create(test_setup.tmp_dir.join("create_stdout.txt"))?;
-            let status = Command::new(std::env::current_exe()?)
-                .arg("start-vm")
-                .arg("--test-case")
-                .arg(&test_setup.test_case)
-                .arg("--tmp-dir")
-                .arg(&test_setup.tmp_dir)
-                .env("KRUN_TEST_SNAPSHOT_CREATE", "1")
-                .stdin(Stdio::null())
-                .stdout(child_stdout)
-                .stderr(Stdio::inherit())
-                .status()?;
-            if !snapshot_dir.join("vmstate").exists() {
-                anyhow::bail!("child did not create a snapshot (exit {status:?})");
-            }
-
-            // Restore onto a fresh, identically-shaped VM and run it. The guest
-            // resumes mid heartbeat-loop, prints the rest to stdout (which the
-            // runner captures for check()), runs to completion, and powers off —
-            // krun_restore returns like krun_start_enter.
-            let ctx = unsafe { krun_call_u32!(krun_create_ctx())? };
-            unsafe { configure_vm(ctx, self.ram_mib, &root_dir, &test_setup.test_case)? };
-            let snapshot_cstr = CString::new(snapshot_dir.as_os_str().as_bytes())?;
-            let rc = unsafe { krun_restore(ctx, snapshot_cstr.as_ptr(), 0) };
-            if rc < 0 {
-                anyhow::bail!("krun_restore failed: {rc}");
-            }
-            Ok(())
+            resume_flow(&test_setup, self.ram_mib)
         }
 
         fn check(self: Box<Self>, stdout: Vec<u8>, _test_setup: TestSetup) -> TestOutcome {
-            let out = String::from_utf8_lossy(&stdout);
-            if !out.contains("HEARTBEAT") {
-                return TestOutcome::Fail(format!(
-                    "restored guest produced no heartbeat; stdout: {out:?}"
-                ));
+            check_resumed(&stdout)
+        }
+    }
+
+    impl Test for TestSnapshotFsCapture {
+        fn should_run(&self) -> ShouldRun {
+            if cfg!(target_os = "macos") {
+                ShouldRun::Yes
+            } else {
+                ShouldRun::No("snapshot is macOS/HVF only")
             }
-            // A real resume picks up mid-loop; a regression that reboots the guest
-            // fresh would re-run the loop from the start and print "HEARTBEAT 0".
-            if out.lines().any(|l| l.trim() == "HEARTBEAT 0") {
-                return TestOutcome::Fail(format!(
-                    "restored guest restarted the loop (HEARTBEAT 0 present) instead of resuming; stdout: {out:?}"
-                ));
+        }
+
+        fn timeout_secs(&self) -> u64 {
+            30
+        }
+
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            let root_dir = setup_rootfs(&test_setup)?;
+            let snapshot_dir = test_setup.tmp_dir.join("snapshot");
+            let ctx = unsafe { krun_call_u32!(krun_create_ctx())? };
+            unsafe {
+                capture(
+                    ctx,
+                    self.ram_mib,
+                    &root_dir,
+                    &test_setup.test_case,
+                    &snapshot_dir,
+                )
             }
-            // ...and it must run the loop to completion, then power off.
-            if !out.contains("HEARTBEAT 79") {
-                return TestOutcome::Fail(format!(
-                    "restored guest did not finish the heartbeat loop; stdout: {out:?}"
-                ));
-            }
-            TestOutcome::Pass
+        }
+
+        fn check(self: Box<Self>, _stdout: Vec<u8>, test_setup: TestSetup) -> TestOutcome {
+            // The snapshot completing (and the process exiting cleanly) is the
+            // test: it means the fs worker was quiesced mid-I/O without hanging.
+            check_snapshot_dir(&test_setup.tmp_dir.join("snapshot"))
         }
     }
 }
@@ -273,6 +328,25 @@ mod guest {
                 println!("HEARTBEAT {i}");
                 let _ = std::io::stdout().flush();
                 std::thread::sleep(std::time::Duration::from_millis(300));
+            }
+        }
+    }
+
+    impl Test for TestSnapshotFsCapture {
+        fn in_guest(self: Box<Self>) {
+            // Keep the virtio-fs worker busy so the snapshot quiesces it mid-I/O:
+            // a tight write / fsync / read / verify loop with no pause, for longer
+            // than the host waits before capturing. The host snapshots and exits
+            // the process (KRUN_SNAPSHOT_EXIT) well before this returns.
+            let path = "/snapshot_io_probe";
+            for i in 0..1_000_000u64 {
+                let payload = format!("iter {i}\n");
+                std::fs::write(path, &payload).expect("virtio-fs write failed");
+                let f = std::fs::File::open(path).expect("virtio-fs open failed");
+                f.sync_all().expect("virtio-fs fsync failed");
+                drop(f);
+                let got = std::fs::read_to_string(path).expect("virtio-fs read failed");
+                assert_eq!(got, payload, "virtio-fs read-back mismatch at {i}");
             }
         }
     }

--- a/tests/test_cases/src/test_snapshot.rs
+++ b/tests/test_cases/src/test_snapshot.rs
@@ -1,11 +1,22 @@
-//! Boot a microVM, trigger an out-of-band snapshot, and verify the on-disk
-//! artifacts. macOS/HVF only (the snapshot backend is HVF for now).
+//! Snapshot/restore tests. macOS/HVF only (the snapshot backend is HVF for now).
+//!
+//! - `snapshot-create` boots a microVM, triggers an out-of-band snapshot, and
+//!   verifies the on-disk artifacts.
+//! - `snapshot-resume` creates a snapshot in a child process, then restores it
+//!   onto a fresh, identically-shaped VM and checks the resumed guest keeps
+//!   running: it resumes mid heartbeat-loop, so its stdout carries the tail of
+//!   the loop but never restarts at `HEARTBEAT 0` the way a fresh boot would.
 
 use macros::{guest, host};
 
 // Only the host side configures the VM, so the guest build never reads this.
 #[cfg_attr(not(feature = "host"), allow(dead_code))]
 pub struct TestSnapshot {
+    pub(crate) ram_mib: u32,
+}
+
+#[cfg_attr(not(feature = "host"), allow(dead_code))]
+pub struct TestSnapshotResume {
     pub(crate) ram_mib: u32,
 }
 
@@ -20,8 +31,99 @@ mod host {
     use std::ffi::{CString, c_char};
     use std::os::fd::AsRawFd;
     use std::os::unix::ffi::OsStrExt;
+    use std::path::Path;
+    use std::process::{Command, Stdio};
     use std::ptr::null;
     use std::time::Duration;
+
+    /// Configure a 1-vCPU VM with a virtio-console (wired to the process stdio)
+    /// and a virtiofs root, running the guest agent for `test_case`. Shared by
+    /// the capture and restore paths so the restored config matches the
+    /// snapshot's manifest (arch/mem/vcpu).
+    unsafe fn configure_vm(
+        ctx: u32,
+        ram_mib: u32,
+        root: &Path,
+        test_case: &str,
+    ) -> anyhow::Result<()> {
+        let root_cstr = CString::new(root.as_os_str().as_bytes())?;
+        let test_case_cstr = CString::new(test_case.to_owned())?;
+        unsafe {
+            krun_call!(krun_set_vm_config(ctx, 1, ram_mib))?;
+            krun_call!(krun_add_virtio_console_default(
+                ctx,
+                std::io::stdin().as_raw_fd(),
+                std::io::stdout().as_raw_fd(),
+                std::io::stderr().as_raw_fd(),
+            ))?;
+            krun_call!(krun_add_virtiofs3(
+                ctx,
+                c"/dev/root".as_ptr(),
+                root_cstr.as_ptr(),
+                0,
+                false,
+            ))?;
+            krun_call!(krun_set_workdir(ctx, c"/".as_ptr()))?;
+            let argv: [*const c_char; 2] = [test_case_cstr.as_ptr(), null()];
+            let envp: [*const c_char; 1] = [null()];
+            krun_call!(krun_set_exec(
+                ctx,
+                c"/guest-agent".as_ptr(),
+                argv.as_ptr(),
+                envp.as_ptr(),
+            ))?;
+        }
+        Ok(())
+    }
+
+    /// Capture a snapshot to `snapshot_dir`: configure the VM, start a thread
+    /// that retries the out-of-band trigger past the initial -ENOENT, then enter
+    /// the guest. The trigger captures and exits the process.
+    unsafe fn capture(
+        ctx: u32,
+        ram_mib: u32,
+        root: &Path,
+        test_case: &str,
+        snapshot_dir: &Path,
+    ) -> anyhow::Result<()> {
+        let snapshot_cstr = CString::new(snapshot_dir.as_os_str().as_bytes())?;
+        unsafe {
+            configure_vm(ctx, ram_mib, root, test_case)?;
+            std::thread::spawn(move || {
+                // Let the guest finish booting and reach steady state (agent
+                // running, console ports open) before capturing — snapshotting
+                // mid-boot leaves device state that can't be cleanly restored.
+                std::thread::sleep(Duration::from_secs(5));
+                loop {
+                    let rc = krun_snapshot_request(ctx, snapshot_cstr.as_ptr(), KRUN_SNAPSHOT_EXIT);
+                    if rc == 0 {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+            });
+            let rc = krun_start_enter(ctx);
+            anyhow::bail!("krun_start_enter returned unexpectedly: {rc}");
+        }
+    }
+
+    fn check_snapshot_dir(dir: &Path) -> TestOutcome {
+        for name in ["manifest.json", "vmstate", "memory.img"] {
+            if !dir.join(name).exists() {
+                return TestOutcome::Fail(format!("missing snapshot file: {name}"));
+            }
+        }
+        let mem_len = std::fs::metadata(dir.join("memory.img")).unwrap().len();
+        if mem_len == 0 {
+            return TestOutcome::Fail("memory.img is empty".into());
+        }
+        let manifest = std::fs::read_to_string(dir.join("manifest.json")).unwrap();
+        if !manifest.contains("\"backend\": \"hvf\"") || !manifest.contains("\"arch\": \"aarch64\"")
+        {
+            return TestOutcome::Fail(format!("unexpected manifest: {manifest}"));
+        }
+        TestOutcome::Pass
+    }
 
     impl Test for TestSnapshot {
         fn should_run(&self) -> ShouldRun {
@@ -38,73 +140,108 @@ mod host {
 
         fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
             let root_dir = setup_rootfs(&test_setup)?;
-            let root_cstr = CString::new(root_dir.as_os_str().as_bytes())?;
             let snapshot_dir = test_setup.tmp_dir.join("snapshot");
-            let snapshot_cstr = CString::new(snapshot_dir.as_os_str().as_bytes())?;
-            // The guest agent dispatches on the test-case name passed as argv[0].
-            let test_case_cstr = CString::new(test_setup.test_case.clone())?;
-
+            let ctx = unsafe { krun_call_u32!(krun_create_ctx())? };
             unsafe {
-                let ctx = krun_call_u32!(krun_create_ctx())?;
-                krun_call!(krun_set_vm_config(ctx, 1, self.ram_mib))?;
-                krun_call!(krun_add_virtio_console_default(
+                capture(
                     ctx,
-                    std::io::stdin().as_raw_fd(),
-                    std::io::stdout().as_raw_fd(),
-                    std::io::stderr().as_raw_fd(),
-                ))?;
-                krun_call!(krun_add_virtiofs3(
-                    ctx,
-                    c"/dev/root".as_ptr(),
-                    root_cstr.as_ptr(),
-                    0,
-                    false,
-                ))?;
-                krun_call!(krun_set_workdir(ctx, c"/".as_ptr()))?;
-                let argv: [*const c_char; 2] = [test_case_cstr.as_ptr(), null()];
-                let envp: [*const c_char; 1] = [null()];
-                krun_call!(krun_set_exec(
-                    ctx,
-                    c"/guest-agent".as_ptr(),
-                    argv.as_ptr(),
-                    envp.as_ptr(),
-                ))?;
-
-                // The ctx registers its control channel only once the VM's event
-                // loop is running, so retry past the initial -ENOENT.
-                std::thread::spawn(move || {
-                    loop {
-                        let rc =
-                            krun_snapshot_request(ctx, snapshot_cstr.as_ptr(), KRUN_SNAPSHOT_EXIT);
-                        if rc == 0 {
-                            break;
-                        }
-                        std::thread::sleep(Duration::from_millis(100));
-                    }
-                });
-
-                // Blocks; captures on the trigger above, then exits the process.
-                let rc = krun_start_enter(ctx);
-                anyhow::bail!("krun_start_enter returned unexpectedly: {rc}");
+                    self.ram_mib,
+                    &root_dir,
+                    &test_setup.test_case,
+                    &snapshot_dir,
+                )
             }
         }
 
         fn check(self: Box<Self>, _stdout: Vec<u8>, test_setup: TestSetup) -> TestOutcome {
-            let dir = test_setup.tmp_dir.join("snapshot");
-            for name in ["manifest.json", "vmstate", "memory.img"] {
-                if !dir.join(name).exists() {
-                    return TestOutcome::Fail(format!("missing snapshot file: {name}"));
-                }
+            check_snapshot_dir(&test_setup.tmp_dir.join("snapshot"))
+        }
+    }
+
+    impl Test for TestSnapshotResume {
+        fn should_run(&self) -> ShouldRun {
+            if cfg!(target_os = "macos") {
+                ShouldRun::Yes
+            } else {
+                ShouldRun::No("snapshot is macOS/HVF only")
             }
-            let mem_len = std::fs::metadata(dir.join("memory.img")).unwrap().len();
-            if mem_len == 0 {
-                return TestOutcome::Fail("memory.img is empty".into());
+        }
+
+        fn timeout_secs(&self) -> u64 {
+            90
+        }
+
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            let root_dir = setup_rootfs(&test_setup)?;
+            let snapshot_dir = test_setup.tmp_dir.join("snapshot");
+
+            // A child process (re-exec of this binary with the same test case)
+            // captures the snapshot first; HVF allows one VM per process, so the
+            // child fully exits before we build the restore VM here. Its guest
+            // console goes to a separate file so the stdout the runner captures
+            // is exactly the restored guest's output.
+            if std::env::var_os("KRUN_TEST_SNAPSHOT_CREATE").is_some() {
+                let ctx = unsafe { krun_call_u32!(krun_create_ctx())? };
+                return unsafe {
+                    capture(
+                        ctx,
+                        self.ram_mib,
+                        &root_dir,
+                        &test_setup.test_case,
+                        &snapshot_dir,
+                    )
+                };
             }
-            let manifest = std::fs::read_to_string(dir.join("manifest.json")).unwrap();
-            if !manifest.contains("\"backend\": \"hvf\"")
-                || !manifest.contains("\"arch\": \"aarch64\"")
-            {
-                return TestOutcome::Fail(format!("unexpected manifest: {manifest}"));
+
+            let child_stdout = std::fs::File::create(test_setup.tmp_dir.join("create_stdout.txt"))?;
+            let status = Command::new(std::env::current_exe()?)
+                .arg("start-vm")
+                .arg("--test-case")
+                .arg(&test_setup.test_case)
+                .arg("--tmp-dir")
+                .arg(&test_setup.tmp_dir)
+                .env("KRUN_TEST_SNAPSHOT_CREATE", "1")
+                .stdin(Stdio::null())
+                .stdout(child_stdout)
+                .stderr(Stdio::inherit())
+                .status()?;
+            if !snapshot_dir.join("vmstate").exists() {
+                anyhow::bail!("child did not create a snapshot (exit {status:?})");
+            }
+
+            // Restore onto a fresh, identically-shaped VM and run it. The guest
+            // resumes mid heartbeat-loop, prints the rest to stdout (which the
+            // runner captures for check()), runs to completion, and powers off —
+            // krun_restore returns like krun_start_enter.
+            let ctx = unsafe { krun_call_u32!(krun_create_ctx())? };
+            unsafe { configure_vm(ctx, self.ram_mib, &root_dir, &test_setup.test_case)? };
+            let snapshot_cstr = CString::new(snapshot_dir.as_os_str().as_bytes())?;
+            let rc = unsafe { krun_restore(ctx, snapshot_cstr.as_ptr(), 0) };
+            if rc < 0 {
+                anyhow::bail!("krun_restore failed: {rc}");
+            }
+            Ok(())
+        }
+
+        fn check(self: Box<Self>, stdout: Vec<u8>, _test_setup: TestSetup) -> TestOutcome {
+            let out = String::from_utf8_lossy(&stdout);
+            if !out.contains("HEARTBEAT") {
+                return TestOutcome::Fail(format!(
+                    "restored guest produced no heartbeat; stdout: {out:?}"
+                ));
+            }
+            // A real resume picks up mid-loop; a regression that reboots the guest
+            // fresh would re-run the loop from the start and print "HEARTBEAT 0".
+            if out.lines().any(|l| l.trim() == "HEARTBEAT 0") {
+                return TestOutcome::Fail(format!(
+                    "restored guest restarted the loop (HEARTBEAT 0 present) instead of resuming; stdout: {out:?}"
+                ));
+            }
+            // ...and it must run the loop to completion, then power off.
+            if !out.contains("HEARTBEAT 79") {
+                return TestOutcome::Fail(format!(
+                    "restored guest did not finish the heartbeat loop; stdout: {out:?}"
+                ));
             }
             TestOutcome::Pass
         }
@@ -121,6 +258,22 @@ mod guest {
             // Stay alive long enough to be captured; the host snapshots and
             // exits the process well before this returns.
             std::thread::sleep(std::time::Duration::from_secs(60));
+        }
+    }
+
+    impl Test for TestSnapshotResume {
+        fn in_guest(self: Box<Self>) {
+            use std::io::Write;
+            // Emit heartbeats over a bounded window wide enough that the capture
+            // (taken ~5s in, once the guest is at steady state) lands mid-loop.
+            // The capture child is killed (KRUN_SNAPSHOT_EXIT) partway through;
+            // the restored guest resumes mid-loop, prints the rest, then returns
+            // and powers off so krun_restore exits.
+            for i in 0..80 {
+                println!("HEARTBEAT {i}");
+                let _ = std::io::stdout().flush();
+                std::thread::sleep(std::time::Duration::from_millis(300));
+            }
         }
     }
 }

--- a/tests/test_cases/src/test_snapshot.rs
+++ b/tests/test_cases/src/test_snapshot.rs
@@ -1,0 +1,126 @@
+//! Boot a microVM, trigger an out-of-band snapshot, and verify the on-disk
+//! artifacts. macOS/HVF only (the snapshot backend is HVF for now).
+
+use macros::{guest, host};
+
+// Only the host side configures the VM, so the guest build never reads this.
+#[cfg_attr(not(feature = "host"), allow(dead_code))]
+pub struct TestSnapshot {
+    pub(crate) ram_mib: u32,
+}
+
+#[host]
+mod host {
+    use super::*;
+
+    use crate::common::setup_rootfs;
+    use crate::{ShouldRun, Test, TestOutcome, TestSetup};
+    use crate::{krun_call, krun_call_u32};
+    use krun_sys::*;
+    use std::ffi::{CString, c_char};
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+    use std::ptr::null;
+    use std::time::Duration;
+
+    impl Test for TestSnapshot {
+        fn should_run(&self) -> ShouldRun {
+            if cfg!(target_os = "macos") {
+                ShouldRun::Yes
+            } else {
+                ShouldRun::No("snapshot is macOS/HVF only")
+            }
+        }
+
+        fn timeout_secs(&self) -> u64 {
+            30
+        }
+
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            let root_dir = setup_rootfs(&test_setup)?;
+            let root_cstr = CString::new(root_dir.as_os_str().as_bytes())?;
+            let snapshot_dir = test_setup.tmp_dir.join("snapshot");
+            let snapshot_cstr = CString::new(snapshot_dir.as_os_str().as_bytes())?;
+            // The guest agent dispatches on the test-case name passed as argv[0].
+            let test_case_cstr = CString::new(test_setup.test_case.clone())?;
+
+            unsafe {
+                let ctx = krun_call_u32!(krun_create_ctx())?;
+                krun_call!(krun_set_vm_config(ctx, 1, self.ram_mib))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
+                krun_call!(krun_add_virtiofs3(
+                    ctx,
+                    c"/dev/root".as_ptr(),
+                    root_cstr.as_ptr(),
+                    0,
+                    false,
+                ))?;
+                krun_call!(krun_set_workdir(ctx, c"/".as_ptr()))?;
+                let argv: [*const c_char; 2] = [test_case_cstr.as_ptr(), null()];
+                let envp: [*const c_char; 1] = [null()];
+                krun_call!(krun_set_exec(
+                    ctx,
+                    c"/guest-agent".as_ptr(),
+                    argv.as_ptr(),
+                    envp.as_ptr(),
+                ))?;
+
+                // The ctx registers its control channel only once the VM's event
+                // loop is running, so retry past the initial -ENOENT.
+                std::thread::spawn(move || {
+                    loop {
+                        let rc =
+                            krun_snapshot_request(ctx, snapshot_cstr.as_ptr(), KRUN_SNAPSHOT_EXIT);
+                        if rc == 0 {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(100));
+                    }
+                });
+
+                // Blocks; captures on the trigger above, then exits the process.
+                let rc = krun_start_enter(ctx);
+                anyhow::bail!("krun_start_enter returned unexpectedly: {rc}");
+            }
+        }
+
+        fn check(self: Box<Self>, _stdout: Vec<u8>, test_setup: TestSetup) -> TestOutcome {
+            let dir = test_setup.tmp_dir.join("snapshot");
+            for name in ["manifest.json", "vmstate", "memory.img"] {
+                if !dir.join(name).exists() {
+                    return TestOutcome::Fail(format!("missing snapshot file: {name}"));
+                }
+            }
+            let mem_len = std::fs::metadata(dir.join("memory.img")).unwrap().len();
+            if mem_len == 0 {
+                return TestOutcome::Fail("memory.img is empty".into());
+            }
+            let manifest = std::fs::read_to_string(dir.join("manifest.json")).unwrap();
+            if !manifest.contains("\"backend\": \"hvf\"")
+                || !manifest.contains("\"arch\": \"aarch64\"")
+            {
+                return TestOutcome::Fail(format!("unexpected manifest: {manifest}"));
+            }
+            TestOutcome::Pass
+        }
+    }
+}
+
+#[guest]
+mod guest {
+    use super::*;
+    use crate::Test;
+
+    impl Test for TestSnapshot {
+        fn in_guest(self: Box<Self>) {
+            // Stay alive long enough to be captured; the host snapshots and
+            // exits the process well before this returns.
+            std::thread::sleep(std::time::Duration::from_secs(60));
+        }
+    }
+}


### PR DESCRIPTION
**VM snapshot/restore (HVF-first, macOS/aarch64). Tracking #748.** Supersedes M0 #753. Builds on the pause primitive from #767.

Boot a VM, snapshot it to a directory, restore onto a fresh VM, resume — the restored guest picks up mid-workload, runs to completion, and powers off.

## Capture

`krun_snapshot_request` sends `VmCtl::Snapshot(path, flags)` down the same channel `krun_vm_pause` uses. The event loop then: freezes the vCPUs (`Vmm::pause`), quiesces every device, saves the GIC, serializes device + vCPU state, dumps guest RAM, and exits.

Saved: vCPU regs (incl. pointer-auth keys, vtimer + `mach_absolute_time` anchor for CNTVCT continuity), the in-kernel GIC dist/redist blob + per-vCPU ICC, guest RAM, and device state (PL031 RTC + virtio devices via their MMIO transport, including the virtio-mmio ISR). FD-free — transport/queue state only, never host fds.

## Device quiesce

Freezing the vCPUs stops the guest but not a device's worker threads, which own the live queue indices. `VirtioDevice::pause()` stops the workers and hands the queues back; `save()` reads the exact indices from them. `resume(queues)` restarts a device, replacing the old restart hook. Per @mtjhrc's review: how a device stops its workers is its own business, and `pause` must not drain (a worker blocked on a stalled host fd would deadlock) — it stops at a descriptor boundary. Implemented for block, virtio-fs, console, rng and balloon; devices that can't quiesce reject the snapshot rather than being captured mid-flight.

## Restore

`krun_restore(ctx, path, 0)` takes an already-configured context (config-validate — no setter allowlist), validates it against the manifest (arch, memory, vCPU count, and the ordered device topology), hydrates RAM/vCPU/GIC/device state, then enters the guest like `krun_start_enter`.

- Untrusted-snapshot hardening: sysreg/ICC register ids are validated against the capture allowlists; queue rings are validated before use; a malformed vmstate returns an error instead of panicking.
- Device workers are restarted only after the vCPUs report the GIC blob is restored, so an IRQ a worker raises can't be overwritten. Queue eventfds are re-kicked so in-flight descriptors complete.
- Multi-vCPU and nested-virtualization restore are rejected (not yet supported), rather than silently corrupting.

The C API is two functions: `krun_snapshot_request` and `krun_restore`. Both provisional; the internals (`Snapshottable` in the devices crate, arch-keyed `Aarch64VcpuState`, the `vmstate` format) are API-agnostic and survive the typed-API reshape in #718. See `examples/snapshot.c` and the README for usage + limitations.

## Testing (macOS/HVF)

- `snapshot-create` / `snapshot-resume`: capture, restore onto a fresh VM, assert the guest resumes mid-loop and powers off.
- `snapshot-fs-capture`: snapshot while the guest hammers virtio-fs, so the fs worker is quiesced mid-I/O.
- `vm-pause` unregressed. Unit round-trips for `vmstate`, vCPU/RTC/queue, `Manifest::validate`. `clippy -D warnings` (base + `net,blk`) + `fmt` clean.

## Deferred

Per-device internal state beyond queues (e.g. virtio-fs open fids, so a guest that did fs I/O can't resume yet) and a partially-consumed descriptor. `KRUN_SNAPSHOT_RESUME` (capture-and-continue) returns `-ENOTSUP`. Multi-vCPU restore. `MAP_PRIVATE` of `memory.img` (restore copies today). KVM/Linux backend.
