### PR TITLE
macos: support VMs with more than 64GB of RAM

### DIFF
--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -70,10 +70,14 @@ pub fn arch_memory_regions(
         ram_start_addr,
         ram_last_addr,
         shm_start_addr,
+        // To be filled later using GuestMemory.
+        guest_last_addr: 0,
         page_size,
         fdt_addr,
         initrd_addr: fdt_addr - initrd_size,
         firmware_addr: FIRMWARE_START,
+        #[cfg(target_os = "macos")]
+        ipa_size: 0,
     };
     let regions = if let Some(firmware_size) = firmware_size {
         vec![

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -16,11 +16,14 @@ pub struct ArchMemoryInfo {
     pub ram_start_addr: u64,
     pub ram_last_addr: u64,
     pub shm_start_addr: u64,
+    pub guest_last_addr: u64,
     pub page_size: usize,
     #[cfg(target_arch = "aarch64")]
     pub fdt_addr: u64,
     pub initrd_addr: u64,
     pub firmware_addr: u64,
+    #[cfg(target_os = "macos")]
+    pub ipa_size: u32,
 }
 
 /// Module for aarch64 related functionality.

--- a/src/arch/src/riscv64/mod.rs
+++ b/src/arch/src/riscv64/mod.rs
@@ -40,6 +40,8 @@ pub fn arch_memory_regions(
     let info = ArchMemoryInfo {
         ram_last_addr,
         shm_start_addr,
+        // To be filled later using GuestMemory.
+        guest_last_addr: 0,
         page_size,
         initrd_addr: ram_last_addr - layout::FDT_MAX_SIZE as u64 - initrd_size,
         firmware_addr: FIRMWARE_START,

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -195,6 +195,8 @@ pub fn arch_memory_regions(
         ram_above_gap,
         ram_last_addr,
         shm_start_addr,
+        // To be filled later using GuestMemory.
+        guest_last_addr: 0,
         page_size,
         initrd_addr: ram_last_addr - initrd_size,
         firmware_addr,
@@ -265,6 +267,8 @@ pub fn arch_memory_regions(
         ram_above_gap,
         ram_last_addr,
         shm_start_addr,
+        // To be filled later with GuestMemory.
+        guest_last_addr: 0,
         page_size,
         initrd_addr: layout::INITRD_SEV_START,
         firmware_addr: 0,

--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -22,6 +22,7 @@ use std::fmt::{Display, Formatter};
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
+use arch::ArchMemoryInfo;
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 use arch::aarch64::sysreg::{SYSREG_MASK, sys_reg_name};
 use log::debug;
@@ -104,6 +105,10 @@ const EC_AA64_BKPT: u64 = 0x3c;
 pub enum Error {
     EnableEL2,
     FindSymbol(libloading::Error),
+    IpaGetDefault,
+    IpaGetMaximum,
+    IpaSet,
+    IpaTooLow,
     MemoryMap,
     MemoryUnmap,
     NestedCheck,
@@ -127,6 +132,13 @@ impl Display for Error {
         match self {
             EnableEL2 => write!(f, "Error enabling EL2 mode in HVF"),
             FindSymbol(err) => write!(f, "Couldn't find symbol in HVF library: {err}"),
+            IpaGetDefault => write!(f, "Error getting IPA default value"),
+            IpaGetMaximum => write!(f, "Error getting IPA maximum value"),
+            IpaSet => write!(f, "Error setting IPA value"),
+            IpaTooLow => write!(
+                f,
+                "The VM requires an IPA larger than the maximum supported in this system"
+            ),
             MemoryMap => write!(f, "Error registering memory region in HVF"),
             MemoryUnmap => write!(f, "Error unregistering memory region in HVF"),
             NestedCheck => write!(
@@ -238,7 +250,7 @@ static HVF: LazyLock<libloading::Library> = LazyLock::new(|| unsafe {
 });
 
 impl HvfVm {
-    pub fn new(nested_enabled: bool) -> Result<Self, Error> {
+    pub fn new(arch_mem_info: &mut ArchMemoryInfo, nested_enabled: bool) -> Result<Self, Error> {
         let config = unsafe { hv_vm_config_create() };
         if nested_enabled {
             let set_el2_enabled: libloading::Symbol<
@@ -253,6 +265,36 @@ impl HvfVm {
             if ret != HV_SUCCESS {
                 return Err(Error::EnableEL2);
             }
+        }
+
+        let mut ipa_size_default: u32 = 0;
+        let ret = unsafe { hv_vm_config_get_default_ipa_size(&mut ipa_size_default as *mut _) };
+        if ret != HV_SUCCESS {
+            return Err(Error::IpaGetDefault);
+        }
+
+        let mut ipa_size_max: u32 = 0;
+        let ret = unsafe { hv_vm_config_get_max_ipa_size(&mut ipa_size_max as *mut _) };
+        if ret != HV_SUCCESS {
+            return Err(Error::IpaGetMaximum);
+        }
+
+        let mut ipa_size = ipa_size_default;
+        // If the guest's last address is beyond the 64GB line, we need a 40-bit (or larger) IPA.
+        if arch_mem_info.guest_last_addr > 64 * 1024 * 1024 * 1024 {
+            if ipa_size_max < 40 {
+                return Err(Error::IpaTooLow);
+            }
+            ipa_size = ipa_size_max;
+        }
+
+        let ret = unsafe { hv_vm_config_set_ipa_size(config, ipa_size) };
+        if ret != HV_SUCCESS {
+            return Err(Error::IpaSet);
+        }
+        #[cfg(target_os = "macos")]
+        {
+            arch_mem_info.ipa_size = ipa_size;
         }
 
         let ret = unsafe { hv_vm_create(config) };
@@ -378,7 +420,45 @@ impl HvfVcpu<'_> {
         })
     }
 
-    pub fn set_initial_state(&self, entry_addr: u64, fdt_addr: u64) -> Result<(), Error> {
+    pub fn set_initial_state(
+        &self,
+        ipa_size: u32,
+        entry_addr: u64,
+        fdt_addr: u64,
+    ) -> Result<(), Error> {
+        // Set IPA size on MMFR0
+        let ipa_index: u8 = match ipa_size {
+            36 => 1,
+            40 => 2,
+            42 => 3,
+            44 => 4,
+            48 => 5,
+            52 => 6,
+            56 => 7,
+            _ => return Err(Error::VcpuInitialRegisters),
+        };
+        let mut val: u64 = 0;
+        let ret = unsafe {
+            hv_vcpu_get_sys_reg(
+                self.vcpuid,
+                hv_sys_reg_t_HV_SYS_REG_ID_AA64MMFR0_EL1,
+                &mut val as *mut _,
+            )
+        };
+        if ret != HV_SUCCESS {
+            return Err(Error::VcpuInitialRegisters);
+        }
+        let ret = unsafe {
+            hv_vcpu_set_sys_reg(
+                self.vcpuid,
+                hv_sys_reg_t_HV_SYS_REG_ID_AA64MMFR0_EL1,
+                (val & !0xf) | (ipa_index as u64),
+            )
+        };
+        if ret != HV_SUCCESS {
+            return Err(Error::VcpuInitialRegisters);
+        }
+
         if self.nested_enabled {
             let ret = unsafe {
                 hv_vcpu_set_reg(self.vcpuid, hv_reg_t_HV_REG_CPSR, PSTATE_EL2_FAULT_BITS_64)

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -107,7 +107,6 @@ use nix::unistd::isatty;
 use polly::event_manager::{Error as EventManagerError, EventManager};
 use utils::eventfd::EventFd;
 use utils::worker_message::WorkerMessage;
-#[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use vm_memory::Address;
 use vm_memory::Bytes;
 #[cfg(all(feature = "vhost-user", target_os = "linux"))]
@@ -588,14 +587,16 @@ pub fn build_microvm(
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
     let payload = choose_payload(vm_resources)?;
 
-    let (guest_memory, arch_memory_info, mut _shm_manager, payload_config) = create_guest_memory(
-        vm_resources
-            .vm_config()
-            .mem_size_mib
-            .ok_or(StartMicrovmError::MissingMemSizeConfig)?,
-        vm_resources,
-        &payload,
-    )?;
+    #[allow(unused_mut)]
+    let (guest_memory, mut arch_memory_info, mut _shm_manager, payload_config) =
+        create_guest_memory(
+            vm_resources
+                .vm_config()
+                .mem_size_mib
+                .ok_or(StartMicrovmError::MissingMemSizeConfig)?,
+            vm_resources,
+            &payload,
+        )?;
 
     let vcpu_config = vm_resources.vcpu_config();
 
@@ -631,7 +632,11 @@ pub fn build_microvm(
 
     #[cfg(not(feature = "tee"))]
     #[allow(unused_mut)]
-    let mut vm = setup_vm(&guest_memory, vm_resources.nested_enabled)?;
+    let mut vm = setup_vm(
+        &guest_memory,
+        &mut arch_memory_info,
+        vm_resources.nested_enabled,
+    )?;
 
     #[cfg(feature = "tee")]
     let (_kvm, vm) = {
@@ -932,10 +937,11 @@ pub fn build_microvm(
         intc = {
             // If the system supports the in-kernel GIC, use it. Otherwise, fall back to the
             // userspace implementation.
-            let gic = match HvfGicV3::new(vm_resources.vm_config().vcpu_count.unwrap() as u64) {
-                Ok(hvfgic) => IrqChipDevice::new(Box::new(hvfgic)),
-                Err(_) => IrqChipDevice::new(Box::new(GicV3::new(vcpu_list.clone()))),
-            };
+            let gic: IrqChipDevice =
+                match HvfGicV3::new(vm_resources.vm_config().vcpu_count.unwrap() as u64) {
+                    Ok(hvfgic) => IrqChipDevice::new(Box::new(hvfgic)),
+                    Err(_) => IrqChipDevice::new(Box::new(GicV3::new(vcpu_list.clone()))),
+                };
             Arc::new(Mutex::new(gic))
         };
 
@@ -1601,7 +1607,7 @@ pub fn create_guest_memory(
     };
 
     #[cfg(target_arch = "x86_64")]
-    let (arch_mem_info, mut arch_mem_regions) = match payload {
+    let (mut arch_mem_info, mut arch_mem_regions) = match payload {
         #[cfg(not(feature = "tee"))]
         Payload::KernelMmap => {
             let (kernel_guest_addr, kernel_size) =
@@ -1634,7 +1640,7 @@ pub fn create_guest_memory(
         Payload::Firmware => arch::arch_memory_regions(mem_size, None, 0, 0, firmware_size),
     };
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
-    let (arch_mem_info, mut arch_mem_regions) = match payload {
+    let (mut arch_mem_info, mut arch_mem_regions) = match payload {
         Payload::ExternalKernel(external_kernel) => {
             arch::arch_memory_regions(mem_size, external_kernel.initramfs_size, None)
         }
@@ -1749,6 +1755,8 @@ pub fn create_guest_memory(
         pvh,
     };
 
+    arch_mem_info.guest_last_addr = guest_mem.last_addr().raw_value();
+
     Ok((guest_mem, arch_mem_info, shm_manager, payload_config))
 }
 
@@ -1767,6 +1775,7 @@ fn load_cmdline(vmm: &Vmm) -> std::result::Result<(), StartMicrovmError> {
 #[cfg(all(target_os = "linux", not(feature = "tee")))]
 pub(crate) fn setup_vm(
     guest_memory: &GuestMemoryMmap,
+    _arch_mem_info: &mut ArchMemoryInfo,
     _nested_enabled: bool,
 ) -> std::result::Result<Vm, StartMicrovmError> {
     let kvm = KvmContext::new()
@@ -1822,9 +1831,10 @@ pub(crate) fn setup_vm(
 #[cfg(target_os = "macos")]
 pub(crate) fn setup_vm(
     guest_memory: &GuestMemoryMmap,
+    arch_mem_info: &mut ArchMemoryInfo,
     nested_enabled: bool,
 ) -> std::result::Result<Vm, StartMicrovmError> {
-    let mut vm = Vm::new(nested_enabled)
+    let mut vm = Vm::new(arch_mem_info, nested_enabled)
         .map_err(Error::Vm)
         .map_err(StartMicrovmError::Internal)?;
     vm.memory_init(guest_memory)
@@ -2043,6 +2053,7 @@ fn create_vcpus_aarch64(
 
         let mut vcpu = Vcpu::new_aarch64(
             cpu_index,
+            mem_info.ipa_size,
             entry_addr,
             boot_receiver,
             exit_evt.try_clone().map_err(Error::EventFd)?,
@@ -2800,9 +2811,9 @@ pub mod tests {
             nested_enabled: false,
         };
 
-        let (guest_memory, _arch_memory_info, _shm_manager, _payload_config) =
+        let (guest_memory, mut arch_memory_info, _shm_manager, _payload_config) =
             default_guest_memory(128).unwrap();
-        let vm = setup_vm(&guest_memory, false).unwrap();
+        let vm = setup_vm(&guest_memory, &mut arch_memory_info, false).unwrap();
         let _kvmioapic = KvmIoapic::new(vm.fd()).unwrap();
 
         // Dummy entry_addr, vcpus will not boot.
@@ -2825,9 +2836,9 @@ pub mod tests {
     #[test]
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     fn test_create_vcpus_aarch64() {
-        let (guest_memory, arch_memory_info, _shm_manager, _payload_config) =
+        let (guest_memory, mut arch_memory_info, _shm_manager, _payload_config) =
             default_guest_memory(128).unwrap();
-        let vm = setup_vm(&guest_memory, false).unwrap();
+        let vm = setup_vm(&guest_memory, &mut arch_memory_info, false).unwrap();
         let vcpu_count = 2;
 
         let vcpu_config = VcpuConfig {

--- a/src/vmm/src/device_manager/kvm/mmio.rs
+++ b/src/vmm/src/device_manager/kvm/mmio.rs
@@ -421,7 +421,8 @@ mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let vm = builder::setup_vm(&guest_mem, false).unwrap();
+        let mut arch_mem_info = arch::ArchMemoryInfo::default();
+        let vm = builder::setup_vm(&guest_mem, &mut arch_mem_info, false).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         #[cfg(target_arch = "x86_64")]
@@ -445,7 +446,8 @@ mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let vm = builder::setup_vm(&guest_mem, false).unwrap();
+        let mut arch_mem_info = arch::ArchMemoryInfo::default();
+        let vm = builder::setup_vm(&guest_mem, &mut arch_mem_info, false).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         #[cfg(target_arch = "x86_64")]
@@ -548,7 +550,8 @@ mod tests {
         let start_addr2 = GuestAddress(0x1000);
         let guest_mem =
             GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
-        let vm = builder::setup_vm(&guest_mem, false).unwrap();
+        let mut arch_mem_info = arch::ArchMemoryInfo::default();
+        let vm = builder::setup_vm(&guest_mem, &mut arch_mem_info, false).unwrap();
         let mut device_manager =
             MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
         let mut cmdline = kernel_cmdline::Cmdline::new(4096);

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -97,8 +97,8 @@ pub struct Vm {
 
 impl Vm {
     /// Constructs a new `Vm` using the given `Kvm` instance.
-    pub fn new(nested_enabled: bool) -> Result<Self> {
-        let hvf_vm = HvfVm::new(nested_enabled).map_err(Error::VmSetup)?;
+    pub fn new(arch_mem_info: &mut ArchMemoryInfo, nested_enabled: bool) -> Result<Self> {
+        let hvf_vm = HvfVm::new(arch_mem_info, nested_enabled).map_err(Error::VmSetup)?;
 
         Ok(Vm { hvf_vm })
     }
@@ -178,6 +178,7 @@ type VcpuCell = Cell<Option<*const Vcpu>>;
 /// A wrapper around creating and using a kvm-based VCPU.
 pub struct Vcpu {
     id: u8,
+    ipa_size: u32,
     boot_entry_addr: u64,
     boot_receiver: Option<Receiver<u64>>,
     boot_senders: Option<HashMap<u64, Sender<u64>>>,
@@ -269,6 +270,7 @@ impl Vcpu {
     /// * `exit_evt` - An `EventFd` that will be written into when this vcpu exits.
     pub fn new_aarch64(
         id: u8,
+        ipa_size: u32,
         boot_entry_addr: GuestAddress,
         boot_receiver: Option<Receiver<u64>>,
         exit_evt: EventFd,
@@ -280,6 +282,7 @@ impl Vcpu {
 
         Ok(Vcpu {
             id,
+            ipa_size,
             boot_entry_addr: boot_entry_addr.raw_value(),
             boot_receiver,
             boot_senders: None,
@@ -454,7 +457,7 @@ impl Vcpu {
         };
 
         hvf_vcpu
-            .set_initial_state(entry_addr, self.fdt_addr)
+            .set_initial_state(self.ipa_size, entry_addr, self.fdt_addr)
             .unwrap_or_else(|_| panic!("Can't set HVF vCPU {hvf_vcpuid} initial state"));
 
         loop {


### PR DESCRIPTION
Check if the last address in the VM goes beyond the 64GB line and, if that's the case, try to use a 40-bit IPA, if supported by the system.

This enables us to both run VMs with more than 64GB of RAM and use GPU windows larger than such value.

Be conservative and keep using a 36-bit IPA if the guest doesn't require a larger one.

Fixes: #764