### PR TITLE
virtio/vsock: don't make the host wait for the reaper on a refused connection

### DIFF
--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -694,18 +694,21 @@ impl VsockMuxer {
     fn process_stream_rst(&self, pkt: &VsockPacket) {
         debug!("OP_RST");
         let id: u64 = ((pkt.src_port() as u64) << 32) | (pkt.dst_port() as u64);
-        if let Some(proxy_lock) = self.proxy_map.read().unwrap().get(&id) {
+        let update = if let Some(proxy_lock) = self.proxy_map.read().unwrap().get(&id) {
             debug!(
                 "allowing OP_RST: id={} src={} dst={}",
                 id,
                 pkt.src_port(),
                 pkt.dst_port()
             );
-            let mut proxy = proxy_lock.lock().unwrap();
-            let update = proxy.release();
-            self.process_proxy_update(id, update);
+            Some(proxy_lock.lock().unwrap().release())
         } else {
             debug!("invalid OP_RST for {}", pkt.src_port());
+            None
+        };
+
+        if let Some(update) = update {
+            self.process_proxy_update(id, update);
         }
     }
 

--- a/src/devices/src/virtio/vsock/unix_proxy/unix.rs
+++ b/src/devices/src/virtio/vsock/unix_proxy/unix.rs
@@ -327,7 +327,15 @@ pub(crate) fn release(proxy: &mut super::UnixProxy) -> ProxyUpdate {
         "release: id={}, tx_cnt={}, last_tx_cnt={}",
         proxy.id, proxy.tx_cnt, proxy.last_tx_cnt_sent
     );
-    let remove_proxy = ProxyRemoval::Deferred;
+
+    // A connection that never reached Connected carries no data and is not
+    // registered for polling yet, so there is nothing to reserve its id for.
+    // Keeping it would leave the accepted host socket open, and its peer
+    // blocked, until the reaper reclaims the proxy.
+    let remove_proxy = match proxy.status {
+        ProxyStatus::ReverseInit | ProxyStatus::Connecting => ProxyRemoval::Immediate,
+        _ => ProxyRemoval::Deferred,
+    };
 
     ProxyUpdate {
         remove_proxy,

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -12,6 +12,11 @@ mod test_vsock_guest_connect;
 #[cfg(any(feature = "host", target_os = "linux"))]
 use test_vsock_guest_connect::TestVsockGuestConnect;
 
+#[cfg(any(feature = "host", target_os = "linux"))]
+mod test_vsock_host_connect_refused;
+#[cfg(any(feature = "host", target_os = "linux"))]
+use test_vsock_host_connect_refused::TestVsockHostConnectRefused;
+
 mod test_tsi_tcp_guest_connect;
 use test_tsi_tcp_guest_connect::TestTsiTcpGuestConnect;
 
@@ -101,6 +106,11 @@ pub fn test_cases() -> Vec<TestCase> {
         TestCase::new("vm-pause", Box::new(TestVmPause)),
         #[cfg(any(feature = "host", target_os = "linux"))]
         TestCase::new("vsock-guest-connect", Box::new(TestVsockGuestConnect)),
+        #[cfg(any(feature = "host", target_os = "linux"))]
+        TestCase::new(
+            "vsock-host-connect-refused",
+            Box::new(TestVsockHostConnectRefused),
+        ),
         TestCase::new(
             "tsi-tcp-guest-connect",
             Box::new(TestTsiTcpGuestConnect::new()),

--- a/tests/test_cases/src/test_vsock_host_connect_refused.rs
+++ b/tests/test_cases/src/test_vsock_host_connect_refused.rs
@@ -1,0 +1,196 @@
+#![cfg(any(feature = "host", target_os = "linux"))]
+
+use macros::{guest, host};
+
+pub struct TestVsockHostConnectRefused;
+
+/// The guest connects out on this port, which tells the host that the guest's
+/// vsock stack is up and a request to an unbound port will be answered.
+const READY_PORT: u32 = 1234;
+
+#[host]
+mod host {
+    use super::*;
+    use crate::common::setup_fs_and_enter;
+    use crate::{Test, TestOutcome, TestSetup};
+    use crate::{krun_call, krun_call_u32};
+    use krun_sys::*;
+    use std::ffi::CString;
+    use std::io::{Read, Write};
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::os::unix::prelude::OsStrExt;
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, Instant};
+    use std::{mem, thread};
+
+    /// Registered with `listen=true`, but nothing in the guest ever binds it, so
+    /// the guest replies OP_RST to libkrun's OP_REQUEST.
+    const REFUSED_PORT: u32 = 1235;
+
+    /// The RST arrives within a few milliseconds. libkrun used to keep the
+    /// accepted host socket inside a proxy awaiting the vsock reaper's 5s TTL, so
+    /// the host's read() only returned once that expired.
+    const MAX_REFUSE_MS: u128 = 1000;
+
+    const PROBE_PREFIX: &str = "PROBE ";
+    const REFUSED: &str = "refused";
+
+    const SOCKET_WAIT: Duration = Duration::from_secs(10);
+    const READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Time a connect+read against a port no guest process listens on. Reports
+    /// the outcome on stdout so `check` can assert on it.
+    fn probe(sock_path: &Path) -> String {
+        let deadline = Instant::now() + SOCKET_WAIT;
+        while !sock_path.exists() {
+            if Instant::now() > deadline {
+                return format!("{PROBE_PREFIX}no-socket 0");
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let mut stream = match UnixStream::connect(sock_path) {
+            Ok(stream) => stream,
+            Err(e) => return format!("{PROBE_PREFIX}connect-error-{} 0", e.kind()),
+        };
+        stream.set_read_timeout(Some(READ_TIMEOUT)).unwrap();
+
+        let start = Instant::now();
+        let outcome = match stream.read(&mut [0u8; 1]) {
+            Ok(0) => REFUSED.to_string(),
+            Ok(n) => format!("unexpected-data-{n}"),
+            Err(e) => format!("read-error-{}", e.kind()),
+        };
+
+        format!("{PROBE_PREFIX}{outcome} {}", start.elapsed().as_millis())
+    }
+
+    fn run(listener: UnixListener, refused_sock: PathBuf) {
+        // Returns once the guest has connected, so its vsock stack is up.
+        let (mut ready, _addr) = listener.accept().unwrap();
+
+        let mut line = probe(&refused_sock);
+        line.push('\n');
+        std::io::stdout().write_all(line.as_bytes()).unwrap();
+
+        // Release the guest only after the probe line is out, so it cannot
+        // interleave with the guest's console output.
+        ready.write_all(b"go").unwrap();
+
+        // Leak the socket fd, to make sure it is not closed early when we exit the thread
+        mem::forget(ready);
+    }
+
+    impl Test for TestVsockHostConnectRefused {
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            let ready_sock = test_setup.tmp_dir.join("ready.sock");
+            let ready_cstr = CString::new(ready_sock.as_os_str().as_bytes())?;
+            // libkrun binds this one itself, so it must not exist yet.
+            let refused_sock = test_setup.tmp_dir.join("refused.sock");
+            let refused_cstr = CString::new(refused_sock.as_os_str().as_bytes())?;
+
+            let listener = UnixListener::bind(&ready_sock)?;
+            thread::spawn(move || run(listener, refused_sock));
+
+            unsafe {
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
+                let ctx = krun_call_u32!(krun_create_ctx())?;
+                krun_call!(krun_add_vsock(ctx, 0))?;
+                krun_call!(krun_add_vsock_port(ctx, READY_PORT, ready_cstr.as_ptr()))?;
+                krun_call!(krun_add_vsock_port2(
+                    ctx,
+                    REFUSED_PORT,
+                    refused_cstr.as_ptr(),
+                    true
+                ))?;
+                krun_call!(krun_set_vm_config(ctx, 1, 1024))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
+                setup_fs_and_enter(ctx, test_setup)?;
+            }
+            Ok(())
+        }
+
+        fn check(self: Box<Self>, stdout: Vec<u8>, _test_setup: TestSetup) -> TestOutcome {
+            let stdout = String::from_utf8_lossy(&stdout);
+
+            if !stdout.lines().any(|line| line.trim() == "OK") {
+                return TestOutcome::Fail(format!("guest did not report OK, stdout: {stdout:?}"));
+            }
+
+            let Some(probe) = stdout
+                .lines()
+                .find_map(|l| l.trim().strip_prefix(PROBE_PREFIX))
+            else {
+                return TestOutcome::Fail(format!("no probe result, stdout: {stdout:?}"));
+            };
+            let Some((outcome, elapsed_ms)) = probe.split_once(' ') else {
+                return TestOutcome::Fail(format!("malformed probe result: {probe:?}"));
+            };
+            let Ok(elapsed_ms) = elapsed_ms.parse::<u128>() else {
+                return TestOutcome::Fail(format!("malformed probe result: {probe:?}"));
+            };
+
+            if outcome != REFUSED {
+                return TestOutcome::Fail(format!(
+                    "expected the connection to be refused, got {outcome:?}"
+                ));
+            }
+            if elapsed_ms > MAX_REFUSE_MS {
+                return TestOutcome::Fail(format!(
+                    "connecting to a port no guest process listens on took {elapsed_ms}ms to be \
+                     refused, limit is {MAX_REFUSE_MS}ms: libkrun is holding the host socket open \
+                     until the vsock reaper reclaims the proxy"
+                ));
+            }
+
+            TestOutcome::Pass
+        }
+
+        fn timeout_secs(&self) -> u64 {
+            30
+        }
+    }
+}
+
+#[guest]
+mod guest {
+    use super::*;
+    use crate::Test;
+    use nix::libc::VMADDR_CID_HOST;
+    use nix::sys::socket::{AddressFamily, SockFlag, SockType, VsockAddr, connect, socket};
+    use std::io::Read;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::UnixStream;
+
+    impl Test for TestVsockHostConnectRefused {
+        fn in_guest(self: Box<Self>) {
+            let sock = socket(
+                AddressFamily::Vsock,
+                SockType::Stream,
+                SockFlag::empty(),
+                None,
+            )
+            .unwrap();
+            let addr = VsockAddr::new(VMADDR_CID_HOST, READY_PORT);
+            connect(sock.as_raw_fd(), &addr).unwrap();
+            let mut stream = UnixStream::from(sock);
+
+            // Nothing here ever binds REFUSED_PORT: the host probes it while we
+            // wait, and releases us once it has its answer.
+            stream.read_exact(&mut [0u8; 2]).unwrap();
+
+            println!("OK");
+        }
+    }
+}


### PR DESCRIPTION
The first host-to-guest vsock connection after VM start blocks for ~5 seconds
before failing, which makes any caller that probes for guest readiness over
vsock see a cold start dominated by that one block.

Fixes #684. A standalone C reproducer is attached to that issue (#683).

## What happens

A host process connects to a unix socket registered with
`krun_add_vsock_port2(..., listen=true)`. libkrun accepts it at the unix layer
immediately -- before the guest leg of the connection exists -- and sends
OP_REQUEST to the guest. If nothing in the guest listens on that port yet, the
guest answers OP_RST about 3 ms later:

.393744 unix]  new_reverse: id=5301052505799 local_port=1062862535 peer_port=1234
.396743 muxer] OP_RST
.396752 unix]  release: id=..., tx_cnt=0
.396756 muxer] deferring proxy removal: ...
   attempt[1] +5003.62 ms  read=EOF

So the refusal is known in 3 ms and delivered in 5 s. `UnixProxy::release()`
returned `ProxyRemoval::Deferred`, which keeps the proxy -- and the accepted
host socket it owns -- alive until the reaper reclaims it after its 5 s TTL.
The host's `read()` blocks until the fd is finally closed.

Deferred removal reserves a connection id the way TIME_WAIT does. That only
makes sense once the connection existed; a proxy that never reached Connected
has nothing in flight and is not yet registered with the muxer's epoll (that
happens later, in `update_peer_credit()`), so it can simply be dropped.

## The two commits

Returning `ProxyRemoval::Immediate` is the obvious fix, and on its own it
**deadlocks the muxer thread**: `process_stream_rst()` holds a `proxy_map` read
guard across `process_proxy_update()`, which takes the write lock on the same
`RwLock`. The trace log stops dead at "immediately removing proxy" and no
further vsock connection on that VM succeeds. The sibling
`process_proxy_release()` already scopes its guard to avoid this, so the first
commit makes `process_stream_rst()` match it. That is latent today -- nothing
reaches `Immediate` from this path until the second commit -- but
`TsiStreamProxy::release()` already returns `Immediate` when Listening, so it
is worth fixing regardless.

The second commit makes `UnixProxy::release()` state-aware: `Immediate` for
`ReverseInit`/`Connecting`, `Deferred` unchanged for connections that reached
Connected.

## Measurements

libkrunfw 5.5.0 (bundled kernel 6.12.87), host kernel 6.18, x86_64. Time to the
first successful round trip after VM start, by the caller's per-probe timeout:

| per-probe timeout | before | after |
| --- | --- | --- |
| none (block to EOF) | 5338 ms | 415 ms |
| 2000 ms | 2335 ms | 398 ms |
| 100 ms | 435 ms | 375 ms |
| 10 ms | 411 ms | 379 ms |

Cold start no longer depends on the caller's probe deadline -- it is now
dominated by guest boot (the unix socket appears at ~334 ms). Warm round trips
are unchanged at ~0.17 ms.

A retrying caller also stops accumulating proxies: 200 back-to-back refused
connections retained 200 file descriptors for the reaper window before this
change, and none after it.

## Testing

New integration test `vsock-host-connect-refused`. Nothing in the suite
exercised `krun_add_vsock_port2(..., listen=true)` before this. Since the
harness has no guest-ready signal, the test derives one from a second port: the
guest connects out on 1234, and the host's `accept()` returning proves the
guest's vsock stack is up and will answer a request for an unbound port.
Probing port 1235, which the guest never binds, is then independent of boot
timing. The host asserts the connection is refused (a real EOF, not a timeout)
within 1 s; measured 0 ms fixed, 5000 ms unfixed, so the threshold has wide
margin either way.

- Full suite passes at the branch tip: 11/11, 18 skipped (freebsd assets,
  `IPERF_DURATION`, `PJDFSTEST_REPO` unset).
- Each commit builds, and vsock + TSI tests pass with the first commit alone.
- Negative control: the new test fails with "took 5000ms to be refused, limit
  is 1000ms" against a library built from the first commit only.
- `cargo fmt --check` clean.

Not verified, flagging honestly:
- Linux/KVM x86_64 only; `unix.rs` and `muxer.rs` are shared with macOS/HVF.
