### PR TITLE
Add vhost user gpu scanout

### DIFF
--- a/examples/gui_vm/src/main.rs
+++ b/examples/gui_vm/src/main.rs
@@ -7,12 +7,13 @@ use gtk_display::{
 
 use krun_sys::{
     KRUN_LOG_LEVEL_TRACE, KRUN_LOG_LEVEL_WARN, KRUN_LOG_STYLE_ALWAYS, KRUN_LOG_TARGET_DEFAULT,
+    KRUN_VHOST_USER_GPU_NUM_QUEUES, KRUN_VHOST_USER_GPU_SHM_SIZE, KRUN_VIRTIO_DEVICE_GPU,
     VIRGLRENDERER_RENDER_SERVER, VIRGLRENDERER_THREAD_SYNC, VIRGLRENDERER_USE_ASYNC_FENCE_CB,
     VIRGLRENDERER_USE_EGL, VIRGLRENDERER_VENUS, krun_add_display, krun_add_input_device,
-    krun_add_input_device_fd, krun_add_virtio_console_default, krun_add_virtiofs3, krun_create_ctx,
-    krun_display_set_dpi, krun_display_set_physical_size, krun_display_set_refresh_rate,
-    krun_init_log, krun_set_display_backend, krun_set_gpu_options2, krun_set_vm_config,
-    krun_start_enter,
+    krun_add_input_device_fd, krun_add_vhost_user_device, krun_add_virtio_console_default,
+    krun_add_virtiofs3, krun_create_ctx, krun_display_set_dpi, krun_display_set_physical_size,
+    krun_display_set_refresh_rate, krun_init_log, krun_set_display_backend, krun_set_gpu_options2,
+    krun_set_vm_config, krun_start_enter,
 };
 use log::LevelFilter;
 use regex::{Captures, Regex};
@@ -117,6 +118,10 @@ struct Args {
     /// Passthrough an input device (e.g. /dev/input/event0)
     #[arg(long)]
     input: Vec<PathBuf>,
+
+    /// Use vhost-user GPU backend at the given socket path (disables built-in GPU)
+    #[arg(long)]
+    vhost_user_gpu: Option<CString>,
 }
 
 fn krun_thread(
@@ -156,15 +161,28 @@ fn krun_thread(
             std::io::stderr().as_raw_fd(),
         ))?;
 
-        krun_call!(krun_set_gpu_options2(
-            ctx,
-            VIRGLRENDERER_USE_EGL
-                | VIRGLRENDERER_VENUS
-                | VIRGLRENDERER_RENDER_SERVER
-                | VIRGLRENDERER_THREAD_SYNC
-                | VIRGLRENDERER_USE_ASYNC_FENCE_CB,
-            4096
-        ))?;
+        if let Some(socket_path) = &args.vhost_user_gpu {
+            let queue_sizes = [1024u16; KRUN_VHOST_USER_GPU_NUM_QUEUES as usize];
+            krun_call!(krun_add_vhost_user_device(
+                ctx,
+                KRUN_VIRTIO_DEVICE_GPU,
+                socket_path.as_ptr(),
+                std::ptr::null(),
+                KRUN_VHOST_USER_GPU_NUM_QUEUES as u16,
+                queue_sizes.as_ptr(),
+                KRUN_VHOST_USER_GPU_SHM_SIZE,
+            ))?;
+        } else {
+            krun_call!(krun_set_gpu_options2(
+                ctx,
+                VIRGLRENDERER_USE_EGL
+                    | VIRGLRENDERER_VENUS
+                    | VIRGLRENDERER_RENDER_SERVER
+                    | VIRGLRENDERER_THREAD_SYNC
+                    | VIRGLRENDERER_USE_ASYNC_FENCE_CB,
+                4096
+            ))?;
+        }
 
         krun_call!(krun_add_virtiofs3(
             ctx,

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -684,7 +684,7 @@ int krun_add_input_device_fd(uint32_t ctx_id, int input_fd);
  */
 #define KRUN_VHOST_USER_GPU_NUM_QUEUES 2
 #define KRUN_VHOST_USER_GPU_QUEUE_SIZES ((uint16_t[]){1024, 1024})
-#define KRUN_VHOST_USER_GPU_SHM_SIZE (UINT64_C(1) << 33)
+#define KRUN_VHOST_USER_GPU_SHM_SIZE (1ULL << 33)
 
 /**
  * Vhost-user media device default queue configuration.
@@ -692,7 +692,7 @@ int krun_add_input_device_fd(uint32_t ctx_id, int input_fd);
  */
 #define KRUN_VHOST_USER_MEDIA_NUM_QUEUES 2
 #define KRUN_VHOST_USER_MEDIA_QUEUE_SIZES ((uint16_t[]){1024, 1024})
-#define KRUN_VHOST_USER_MEDIA_SHM_SIZE (UINT64_C(1) << 32)
+#define KRUN_VHOST_USER_MEDIA_SHM_SIZE (1ULL << 32)
 
 /**
  * Add a vhost-user device to the VM.

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -20,7 +20,7 @@ virgl_resource_map2 = []
 aws-nitro = []
 test_utils = []
 timesync = []
-vhost-user = ["vhost", "vmm-sys-util"]
+vhost-user = ["vhost", "vmm-sys-util", "krun_display"]
 
 [dependencies]
 bitflags = "1.2.0"

--- a/src/devices/src/virtio/vhost_user/device.rs
+++ b/src/devices/src/virtio/vhost_user/device.rs
@@ -11,14 +11,17 @@ use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
 
+use krun_display::{
+    DisplayBackend, DisplayBackendBasicFramebuffer, DisplayBackendInstance, ResourceFormat,
+};
 use log::{debug, error, warn};
 use nix::sys::socket::{ControlMessage, MsgFlags, sendmsg};
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 use utils::eventfd::{EFD_NONBLOCK, EventFd};
 use vhost::vhost_user::gpu_message::{
-    GpuBackendReq, VhostUserGpuHeaderFlag, VirtioGpuDisplayOne, VirtioGpuRect,
-    VirtioGpuRespDisplayInfo, VirtioGpuRespGetEdid,
+    GpuBackendReq, VhostUserGpuHeaderFlag, VhostUserGpuScanout, VhostUserGpuUpdate,
+    VirtioGpuDisplayOne, VirtioGpuRect, VirtioGpuRespDisplayInfo, VirtioGpuRespGetEdid,
 };
 use vhost::vhost_user::message::{
     FrontendReq, VhostUserConfigFlags, VhostUserMMap, VhostUserMMapFlags,
@@ -28,7 +31,7 @@ use vhost::vhost_user::{
     VhostUserProtocolFeatures,
 };
 use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
-use vm_memory::{Address, GuestMemoryBackend, GuestMemoryMmap, GuestMemoryRegion};
+use vm_memory::{Address, ByteValued, GuestMemoryBackend, GuestMemoryMmap, GuestMemoryRegion};
 use vmm_sys_util::eventfd::EventFd as VhostEventFd;
 
 use crate::display::DisplayInfo;
@@ -250,6 +253,30 @@ pub struct VhostUserDevice {
 
     /// Handler for backend-to-frontend requests (BACKEND_REQ protocol feature)
     backend_req_handler: Option<FrontendReqHandler<Mutex<BackendReqInner>>>,
+    display_backend: Option<DisplayBackend<'static>>,
+
+    display_instance: Option<EpollThreadLocal<DisplayBackendInstance>>,
+}
+
+struct EpollThreadLocal<T>(T);
+
+// SAFETY: VhostUserDevice is registered with a single EventManager and its
+// Subscriber::process() is always called from the same epoll thread. The
+// DisplayBackendInstance inside is created and used exclusively in that
+// callback, so it never actually crosses a thread boundary.
+unsafe impl<T> Send for EpollThreadLocal<T> {}
+
+impl<T> std::ops::Deref for EpollThreadLocal<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for EpollThreadLocal<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
 }
 
 impl VhostUserDevice {
@@ -273,6 +300,7 @@ impl VhostUserDevice {
         num_queues: u16,
         queue_sizes: &[u16],
         gpu_display: Option<DisplayInfo>,
+        display_backend: Option<DisplayBackend<'static>>,
     ) -> IoResult<Self> {
         debug!(
             "Connecting to vhost-user backend at {}",
@@ -369,6 +397,12 @@ impl VhostUserDevice {
             gpu_display_info,
             shm_region: None,
             backend_req_handler: None,
+            display_backend: if device_type == VIRTIO_ID_GPU {
+                display_backend
+            } else {
+                None
+            },
+            display_instance: None,
         })
     }
 
@@ -729,6 +763,7 @@ impl VirtioDevice for VhostUserDevice {
 
 impl VhostUserDevice {
     fn handle_gpu_socket_event(&mut self, event: &EpollEvent) {
+        debug!("{}: GPU socket event received", self.device_name);
         let event_set = event.event_set();
 
         if event_set.contains(EventSet::HANG_UP) || event_set.contains(EventSet::ERROR) {
@@ -790,9 +825,17 @@ impl VhostUserDevice {
     }
 
     fn handle_gpu_message(&mut self, request: u32, _flags: u32, payload: &[u8]) {
+        debug!(
+            "{}: GPU message: request={}, payload_len={}",
+            self.device_name,
+            request,
+            payload.len()
+        );
         match GpuBackendReq::try_from(request) {
             Ok(GpuBackendReq::GET_DISPLAY_INFO) => self.send_gpu_display_info(request),
             Ok(GpuBackendReq::GET_EDID) => self.send_gpu_edid(request, payload),
+            Ok(GpuBackendReq::SCANOUT) => self.handle_gpu_scanout(payload),
+            Ok(GpuBackendReq::UPDATE) => self.handle_gpu_update(payload),
             _ => {
                 warn!("{}: unhandled GPU message: {}", self.device_name, request);
             }
@@ -855,6 +898,164 @@ impl VhostUserDevice {
 
         if let Err(e) = self.send_gpu_response(request, &display_info) {
             error!("{}: failed to send DISPLAY_INFO: {}", self.device_name, e);
+        }
+    }
+
+    fn get_display_instance(&mut self) -> Option<&mut DisplayBackendInstance> {
+        if self.display_instance.is_none()
+            && let Some(backend) = self.display_backend.take()
+        {
+            match backend.create_instance() {
+                Ok(instance) => self.display_instance = Some(EpollThreadLocal(instance)),
+                Err(e) => {
+                    error!(
+                        "{}: failed to create display instance: {e}",
+                        self.device_name
+                    );
+                    return None;
+                }
+            }
+        }
+        self.display_instance.as_deref_mut()
+    }
+
+    fn handle_gpu_scanout(&mut self, payload: &[u8]) {
+        let header_size = std::mem::size_of::<VhostUserGpuScanout>();
+        if payload.len() < header_size {
+            error!("{}: SCANOUT payload too short", self.device_name);
+            return;
+        }
+        let mut scanout = VhostUserGpuScanout::default();
+        scanout
+            .as_mut_slice()
+            .copy_from_slice(&payload[..header_size]);
+
+        let scanout_id = scanout.scanout_id;
+
+        // Validate scanout ID - frontend only advertises scanout 0
+        if scanout_id != 0 {
+            error!(
+                "{}: invalid scanout_id {} (only 0 is supported)",
+                self.device_name, scanout_id
+            );
+            return;
+        }
+
+        if scanout.width == 0 || scanout.height == 0 {
+            debug!("{}: disabling scanout {scanout_id}", self.device_name);
+            if let Some(display) = self.get_display_instance()
+                && let Err(e) = display.disable_scanout(scanout_id)
+            {
+                error!("{}: disable_scanout failed: {e}", self.device_name);
+            }
+            return;
+        }
+
+        debug!(
+            "{}: configuring scanout {scanout_id} ({}x{})",
+            self.device_name, scanout.width, scanout.height
+        );
+
+        let display_info = self.gpu_display_info.as_ref();
+        let display_width = display_info.map_or(scanout.width, |d| d.width);
+        let display_height = display_info.map_or(scanout.height, |d| d.height);
+
+        if let Some(display) = self.get_display_instance()
+            && let Err(e) = display.configure_scanout(
+                scanout_id,
+                display_width,
+                display_height,
+                scanout.width,
+                scanout.height,
+                ResourceFormat::BGRX,
+            )
+        {
+            error!("{}: configure_scanout failed: {e}", self.device_name);
+        }
+    }
+
+    fn handle_gpu_update(&mut self, payload: &[u8]) {
+        let header_size = std::mem::size_of::<VhostUserGpuUpdate>();
+        if payload.len() < header_size {
+            error!("{}: UPDATE payload too short", self.device_name);
+            return;
+        }
+        let mut update = VhostUserGpuUpdate::default();
+        update
+            .as_mut_slice()
+            .copy_from_slice(&payload[..header_size]);
+
+        let pixel_data = &payload[header_size..];
+        let scanout_id = update.scanout_id;
+        let bytes_per_pixel = ResourceFormat::BYTES_PER_PIXEL;
+        let update_x = update.x as usize;
+        let update_y = update.y as usize;
+        let update_width = update.width as usize;
+        let update_height = update.height as usize;
+
+        if scanout_id != 0 {
+            error!(
+                "{}: invalid scanout_id {} (only 0 is supported)",
+                self.device_name, scanout_id
+            );
+            return;
+        }
+
+        let expected_len = update_width * update_height * bytes_per_pixel;
+        if pixel_data.len() < expected_len {
+            error!("{}: UPDATE pixel data too short", self.device_name);
+            return;
+        }
+
+        let scanout_width = self
+            .gpu_display_info
+            .as_ref()
+            .map_or(update_width, |d| d.width as usize);
+        let scanout_height = self
+            .gpu_display_info
+            .as_ref()
+            .map_or(update_height, |d| d.height as usize);
+
+        if update_x + update_width > scanout_width || update_y + update_height > scanout_height {
+            error!(
+                "{}: UPDATE rectangle out of bounds: ({},{}) {}x{} exceeds scanout {}x{}",
+                self.device_name,
+                update_x,
+                update_y,
+                update_width,
+                update_height,
+                scanout_width,
+                scanout_height
+            );
+            return;
+        }
+
+        let Some(display) = self.get_display_instance() else {
+            return;
+        };
+
+        let (frame_id, buffer) = match display.alloc_frame(scanout_id) {
+            Ok(frame) => frame,
+            Err(e) => {
+                error!("{}: alloc_frame failed: {e}", self.device_name);
+                return;
+            }
+        };
+
+        // UPDATE carries a rectangular region (x, y, width, height). For partial updates,
+        // pixel_data contains only the update rectangle, packed row-by-row. Copy each row
+        // into the correct position in the full-frame buffer.
+        for row in 0..update_height {
+            let dst_offset = ((update_y + row) * scanout_width + update_x) * bytes_per_pixel;
+            let src_offset = row * update_width * bytes_per_pixel;
+            let row_bytes = update_width * bytes_per_pixel;
+
+            buffer[dst_offset..dst_offset + row_bytes]
+                .copy_from_slice(&pixel_data[src_offset..src_offset + row_bytes]);
+        }
+
+        if let Err(e) = display.present_frame(scanout_id, frame_id, None) {
+            error!("{}: present_frame failed: {e}", self.device_name);
         }
     }
 

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -18,7 +18,7 @@ gpu = ["devices/gpu", "krun_display"]
 input = ["krun_input", "devices/input"]
 virgl_resource_map2 = ["devices/virgl_resource_map2"]
 aws-nitro = ["devices/aws-nitro", "dep:aws-nitro", "dep:nitro-enclaves"]
-vhost-user = ["devices/vhost-user"]
+vhost-user = ["devices/vhost-user", "krun_display"]
 timesync = ["devices/timesync"]
 
 [dependencies]

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -13,7 +13,7 @@ use devices::virtio::block::{ImageType, SyncMode};
 #[cfg(feature = "net")]
 use devices::virtio::net::device::VirtioNetBackend;
 use env_logger::{Env, Target};
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "gpu", feature = "vhost-user"))]
 use krun_display::DisplayBackend;
 
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
@@ -1445,7 +1445,7 @@ pub unsafe extern "C" fn krun_set_gpu_options2(
     KRUN_SUCCESS
 }
 
-#[cfg(not(feature = "gpu"))]
+#[cfg(not(any(feature = "gpu", feature = "vhost-user")))]
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 pub extern "C" fn krun_set_display_backend(
@@ -1457,7 +1457,7 @@ pub extern "C" fn krun_set_display_backend(
     -libc::ENOTSUP
 }
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "gpu", feature = "vhost-user"))]
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 pub extern "C" fn krun_set_display_backend(

--- a/src/libkrun/src/vmm/builder.rs
+++ b/src/libkrun/src/vmm/builder.rs
@@ -96,7 +96,7 @@ use devices::display::NoopDisplayBackend;
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use devices::virtio::{VirtioShmRegion, fs::ExportTable};
 use flate2::read::GzDecoder;
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "gpu", feature = "vhost-user"))]
 use krun_display::DisplayBackend;
 #[cfg(feature = "gpu")]
 use krun_display::IntoDisplayBackend;
@@ -1228,6 +1228,7 @@ pub fn build_microvm(
                     device_config,
                     index,
                     vm_resources.displays.first().cloned(),
+                    vm_resources.display_backend,
                 )?;
             }
 
@@ -2913,6 +2914,7 @@ fn attach_vhost_user_device(
     device_config: &VhostUserDeviceConfig,
     device_index: usize,
     gpu_display: Option<DisplayInfo>,
+    display_backend: Option<DisplayBackend<'static>>,
 ) -> std::result::Result<(), StartMicrovmError> {
     use self::StartMicrovmError::*;
 
@@ -2929,6 +2931,7 @@ fn attach_vhost_user_device(
             device_config.num_queues,
             &device_config.queue_sizes,
             gpu_display,
+            display_backend,
         )
         .map_err(|e| RegisterVhostUserDevice(device_manager::mmio::Error::VhostUserDevice(e)))?,
     ));

--- a/src/libkrun/src/vmm/resources.rs
+++ b/src/libkrun/src/vmm/resources.rs
@@ -38,7 +38,7 @@ use crate::vmm::vstate::VcpuConfig;
 use devices::display::DisplayInfo;
 #[cfg(feature = "tee")]
 use kbs_types::Tee;
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "gpu", feature = "vhost-user"))]
 use krun_display::DisplayBackend;
 
 type Result<E> = std::result::Result<(), E>;
@@ -211,7 +211,7 @@ pub struct VmResources {
     /// Flags for the virtio-gpu device.
     pub gpu_virgl_flags: Option<u32>,
     pub gpu_shm_size: Option<usize>,
-    #[cfg(feature = "gpu")]
+    #[cfg(any(feature = "gpu", feature = "vhost-user"))]
     pub display_backend: Option<DisplayBackend<'static>>,
     #[cfg(any(feature = "gpu", feature = "vhost-user"))]
     pub displays: Vec<DisplayInfo>,
@@ -447,7 +447,7 @@ mod tests {
             net: Default::default(),
             gpu_virgl_flags: None,
             gpu_shm_size: None,
-            #[cfg(feature = "gpu")]
+            #[cfg(any(feature = "gpu", feature = "vhost-user"))]
             display_backend: None,
             #[cfg(any(feature = "gpu", feature = "vhost-user"))]
             displays: Vec::new(),


### PR DESCRIPTION
### Summary

- Wire the display backend into vhost-user GPU devices to handle software scanout messages (SCANOUT type 7, UPDATE type 8)
- Enable display output when using vhost-device-gpu with the gfxstream backend, which sends raw pixel data over the GPU socket
- Add --vhost-user-gpu option to gui_vm example
- Depends on #815 (EDID fix for standard timings)

The gfxstream backend sends pixel data directly in the UPDATE message payload (software scanout). The
virglrenderer backend instead sends DMABUF file descriptors via SCM_RIGHTS (DMABUF scanout, message
types 9/10/12) - that path is not yet supported and depends on #465  so it'll be a follow-up PR.

The guest falls back to llvmpipe for rendering. Display output works because the gfxstream backend reads 2D resource pixels and sends them over the socket via software scanout.

## Testing

Start the vhost-device-gpu backend with gfxstream:

vhost-device-gpu --socket-path /tmp/gpu.socket --gpu-mode gfxstream

Start gui_vm with vhost-user GPU:

./examples/target/release/gui_vm \
--root-dir /path/to/rootfs \
--display 1024x768 \
--vhost-user-gpu /tmp/gpu.socket \
/bin/bash

In the guest, set the DRM mode before running graphical apps (the CRTC is not configured by default):

modetest -M virtio_gpu -s <connector_id>:<mode>
Find the connector ID and available modes with modetest -M virtio_gpu.
E.g: modetest -M virtio_gpu -s 37:1024x768
Then run benchmarks:

* Spinning cube (~310 FPS with llvmpipe)
kmscube

* glmark2 (score ~128)
glmark2-drm --visual-config id=37