### PR TITLE
arch/x86_64: keep initrd below the MMIO gap

### DIFF
--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -196,7 +196,7 @@ pub fn arch_memory_regions(
         ram_last_addr,
         shm_start_addr,
         page_size,
-        initrd_addr: ram_last_addr - initrd_size,
+        initrd_addr: ram_last_addr.min(MMIO_MEM_START) - initrd_size,
         firmware_addr,
     };
     (info, regions)
@@ -546,6 +546,35 @@ mod tests {
             regions[1].0
         );
         assert_eq!(GuestAddress(1u64 << 32), regions[2].0);
+    }
+
+    #[cfg(not(feature = "tee"))]
+    fn assert_initrd_in_low_ram(memory_size: usize, initrd_size: u64) {
+        let (info, regions) = arch_memory_regions(
+            memory_size,
+            Some(KERNEL_LOAD_ADDR),
+            KERNEL_SIZE,
+            initrd_size,
+            None,
+        );
+        let initrd_end = info.initrd_addr + initrd_size;
+
+        assert_eq!(info.initrd_addr, MMIO_MEM_START - initrd_size);
+        assert!(regions.iter().any(|(start, size)| {
+            let start = start.raw_value();
+            let end = start + *size as u64;
+
+            info.initrd_addr >= start && initrd_end <= end
+        }));
+    }
+
+    #[cfg(not(feature = "tee"))]
+    #[test]
+    fn initrd_stays_in_low_ram_when_memory_crosses_mmio_gap() {
+        const INITRD_SIZE: u64 = 32 << 20;
+
+        assert_initrd_in_low_ram(3330usize << 20, INITRD_SIZE);
+        assert_initrd_in_low_ram(4096usize << 20, INITRD_SIZE);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The x86 Linux direct-boot path writes the initrd address to the legacy
32-bit `ramdisk_image` field without populating `ext_ramdisk_image`.

When guest RAM crosses the MMIO gap, calculating the initrd address
from `ram_last_addr` can place it above 4 GiB. Converting that address
to `u32` discards its upper bits, causing the kernel to read the initrd
from the wrong address and fail to find `/init`.

## Fix

Keep the initrd below the x86 MMIO gap:

```rust
initrd_addr: ram_last_addr.min(MMIO_MEM_START) - initrd_size,
```

This leaves placement unchanged when RAM ends below the gap. When RAM
crosses the gap, it places the initrd at the end of the existing
low-memory RAM region.

The regression covers 3330 MiB, immediately above the MMIO boundary,
and 4096 MiB. It verifies the exact initrd address and that the complete
image is contained within one guest RAM region.

## Testing

- `cargo fmt -- --check`
- `cargo test`
- Verified that the regression fails on the parent commit and passes
  with the fix
- Validated placement at 3330, 4096, 5120, and 8192 MiB on an AWS Linux
  host with nested KVM
- Ubuntu 24.04.4 completed initramfs → rootfs → systemd multi-user boot
  under nested KVM at 5120 MiB and shut down cleanly
