### PR TITLE
ui/gtk: Move window creation to end-users

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -665,6 +665,7 @@ dependencies = [
  "clap",
  "clap_derive",
  "env_logger",
+ "gtk4",
  "gtk_display",
  "krun-init-blob-via-cdylib",
  "krun-input",

--- a/examples/gui_vm/Cargo.toml
+++ b/examples/gui_vm/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 gtk_display = { path = "../krun_gtk_display" }
+gtk = { version = "0.10", package = "gtk4" }
 krun-sys = { path = "../../krun-sys" }
 krun-init = { package = "krun-init-blob-via-cdylib", path = "../../init/init-blob-via-cdylib" }
 krun_input = { path = "../../src/input", package = "krun-input" }

--- a/examples/gui_vm/src/main.rs
+++ b/examples/gui_vm/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use clap_derive::Parser;
+use gtk::prelude::*;
 use gtk_display::{
     Axis, DisplayBackendHandle, DisplayInputOptions, InputBackendHandle, TouchArea,
     TouchScreenOptions,
@@ -269,12 +270,10 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    let (display_backend, input_backends, display_worker) = gtk_display::init(
-        "libkrun examples/gui_vm".to_string(),
-        args.keyboard_input,
-        per_display_inputs,
-    )?;
+    let (display_backend, input_backends, display_worker) =
+        gtk_display::init(args.keyboard_input, per_display_inputs)?;
 
+    let display_args: Vec<DisplayArg> = args.display.clone();
     thread::scope(|s| {
         s.spawn(|| {
             if let Err(e) = krun_thread(&args, display_backend, input_backends) {
@@ -282,7 +281,22 @@ fn main() -> anyhow::Result<()> {
                 exit(1);
             }
         });
-        display_worker.run()
+        display_worker.run(move |worker| {
+            for (idx, display) in display_args.iter().enumerate() {
+                let paintable =
+                    worker.create_paintable(idx, display.width as i32, display.height as i32);
+                let picture = gtk::Picture::for_paintable(&paintable);
+                let window = gtk::Window::builder()
+                    .title(format!(
+                        "libkrun gui_vm - display {idx} ({}x{})",
+                        display.width, display.height
+                    ))
+                    .child(&picture)
+                    .build();
+                window.present();
+                worker.attach_input(idx, &picture);
+            }
+        })
     });
     unreachable!("Expected libkrun (or error handling) to exit the process");
 }

--- a/examples/krun_gtk_display/src/display_worker.rs
+++ b/examples/krun_gtk_display/src/display_worker.rs
@@ -389,7 +389,7 @@ impl ScanoutWindow {
         let overlay = build_overlay(window.as_ref());
         overlay.set_child(Some(&picture));
         window.set_child(Some(&overlay));
-        window.set_visible(true);
+        window.present();
 
         if let Some(keyboard_event_tx) = keyboard_event_tx {
             picture.set_focusable(true);
@@ -421,7 +421,7 @@ impl ScanoutWindow {
 
 impl Drop for ScanoutWindow {
     fn drop(&mut self) {
-        self.window.destroy();
+        self.window.close();
     }
 }
 

--- a/examples/krun_gtk_display/src/display_worker.rs
+++ b/examples/krun_gtk_display/src/display_worker.rs
@@ -3,7 +3,7 @@ use crate::{Axis, DisplayEvent, DisplayInputOptions, TouchArea, TouchScreenOptio
 use krun_display::Rect;
 use krun_input::{InputEvent, InputEventType};
 use log::{debug, trace, warn};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::iter;
 use std::os::fd::AsRawFd;
@@ -18,15 +18,11 @@ use crate::input_constants::{
     SYN_REPORT,
 };
 use gtk::{
-    AlertDialog, Align, Application, ApplicationWindow, Button, EventControllerKey,
-    EventControllerLegacy, EventControllerMotion, HeaderBar, Overlay, Picture, Revealer,
-    RevealerTransitionType, Widget, Window,
+    Application, EventControllerKey, EventControllerLegacy, Picture, Widget,
     gdk::{self, EventSequence, EventType, MemoryFormat, ModifierType, TouchEvent},
-    gio::ActionEntry,
-    gio::Cancellable,
     glib::{
-        self, Bytes, ControlFlow, IOCondition, Propagation, clone::Downgrade,
-        timeout_add_local_once, unix_fd_add_local,
+        Bytes, ControlFlow, IOCondition, Propagation, clone::Downgrade, timeout_add_local_once,
+        unix_fd_add_local,
     },
     graphene::Point,
     prelude::*,
@@ -201,7 +197,7 @@ impl TouchEventSequencedSender {
     }
 
     // None passed as EventSequence implicitly means finger `0`
-    // returns true fi a deferred sync should be scheduled
+    // returns true if a deferred sync should be scheduled
     fn push_event(
         &mut self,
         seq: Option<EventSequence>,
@@ -307,125 +303,27 @@ impl TouchEventSequencedSender {
     }
 }
 
-struct ScanoutWindow {
-    window: ApplicationWindow,
+struct ManagedScanout {
+    paintable: ScanoutPaintable,
     width: i32,
     height: i32,
     format: MemoryFormat,
-    scanout_paintable: ScanoutPaintable,
 }
 
-impl ScanoutWindow {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        app: &Application,
-        title: &str,
-        display_width: i32,
-        display_height: i32,
-        width: i32,
-        height: i32,
-        format: MemoryFormat,
-        keyboard_event_tx: Option<EventSender>,
-        per_display_inputs: Vec<(EventSender, DisplayInputOptions)>,
-    ) -> Self {
-        let header_bar = HeaderBar::new();
-        let window = ApplicationWindow::builder()
-            .application(app)
-            .title(title)
-            .titlebar(&header_bar)
-            .build();
-
-        window.connect_close_request(|window| {
-            let dialog = AlertDialog::builder()
-                .buttons(["Kill VM", "Only close the window", "Cancel"].as_ref())
-                .default_button(0)
-                .cancel_button(2)
-                .modal(true)
-                .message("Do you want kill the VM?")
-                .detail("WARNING: Killing the VM may lead to loss of data or corruption of the VM image.\n\n\
-                If you only close the window the VM will keep running and rendering the display in the background.")
-                .build();
-            dialog.choose(Some(window), None::<&Cancellable>, glib::clone!(
-                #[strong]
-                window,
-                move |b| match b {
-                    Ok(0) => {
-                        // SAFETY: Safe because we are terminating the process anyway.
-                        // Currently, libkrun also uses _exit on normal VM exit, so we mimic that
-                        // behavior here.
-                        unsafe { libc::_exit(125) }
-                    }
-                    Ok(1) => {
-                        window.set_visible(false);
-                    },
-                    Ok(2) => (),
-                    Ok(_) => unreachable!("Unknown action"),
-                    Err(e) => panic!("Failed to select option: {e}"),
-                }
-            ));
-            Propagation::Stop
-        });
-
-        window.add_action_entries([
-            ActionEntry::builder("fullscreen")
-                .activate(move |window: &ApplicationWindow, _, _| window.fullscreen())
-                .build(),
-            ActionEntry::builder("unfullscreen")
-                .activate(move |window: &ApplicationWindow, _, _| window.unfullscreen())
-                .build(),
-        ]);
-
-        let fullscreen_btn = Button::builder()
-            .icon_name("view-fullscreen")
-            .tooltip_text("Enter fullscreen mode")
-            .action_name("win.fullscreen")
-            .build();
-
-        let scanout_paintable = ScanoutPaintable::new(display_width, display_height);
-        let picture = Picture::for_paintable(&scanout_paintable);
-        window.set_titlebar(Some(&header_bar));
-        header_bar.pack_end(&fullscreen_btn);
-
-        let overlay = build_overlay(window.as_ref());
-        overlay.set_child(Some(&picture));
-        window.set_child(Some(&overlay));
-        window.present();
-
-        if let Some(keyboard_event_tx) = keyboard_event_tx {
-            picture.set_focusable(true);
-            picture.grab_focus();
-            attach_keyboard(keyboard_event_tx, &picture);
-        }
-        attach_per_display_inputs(&picture, &overlay, per_display_inputs);
-
-        Self {
-            window,
-            width,
-            height,
-            format,
-            scanout_paintable,
-        }
-    }
-
-    pub fn reconfigure(&mut self, width: i32, height: i32, format: gdk::MemoryFormat) {
+impl ManagedScanout {
+    fn reconfigure(&mut self, width: i32, height: i32, format: MemoryFormat) {
         self.width = width;
         self.height = height;
         self.format = format;
     }
 
-    pub fn update(&self, buffer: Bytes, rect: Option<Rect>) {
-        self.scanout_paintable
+    fn update(&self, buffer: Bytes, rect: Option<Rect>) {
+        self.paintable
             .update(buffer, self.width, self.height, self.format, rect);
     }
 }
 
-impl Drop for ScanoutWindow {
-    fn drop(&mut self) {
-        self.window.close();
-    }
-}
-
-fn attach_keyboard(keyboard_tx: EventSender, widget: &impl IsA<Widget>) {
+pub fn attach_keyboard(keyboard_tx: EventSender, widget: &impl IsA<Widget>) {
     let key_controller = EventControllerKey::new();
 
     // Handle key press events
@@ -489,12 +387,11 @@ fn attach_keyboard(keyboard_tx: EventSender, widget: &impl IsA<Widget>) {
 /// The returned coordinates are normalized where (0..1) corresponds to coords within the paintable
 fn compute_point_inside_paintable(
     picture: &Picture,
-    container: &Overlay,
     (x, y): (f64, f64), // window coords
 ) -> Option<(f64, f64)> {
     let paintable = picture.paintable()?;
 
-    let native = container.native().unwrap();
+    let native = picture.native()?;
     let (x_offset, y_offset) = native.surface_transform();
     let p = native.compute_point(
         picture,
@@ -523,9 +420,8 @@ fn compute_point_inside_paintable(
     Some((x_rel.clamp(0.0, 1.0), y_rel.clamp(0.0, 1.0)))
 }
 
-fn attach_per_display_inputs(
+pub fn attach_per_display_inputs(
     picture: &Picture,
-    overlay: &Overlay,
     per_display_inputs: Vec<(EventSender, DisplayInputOptions)>,
 ) {
     for (tx, options) in per_display_inputs {
@@ -537,11 +433,9 @@ fn attach_per_display_inputs(
                     Rc::new(RefCell::new(TouchEventSequencedSender::new(tx, options)));
 
                 let picture_weak = Downgrade::downgrade(picture);
-                let overlay_weak = Downgrade::downgrade(overlay);
 
                 input_controller.connect_event(move |_, event| {
                     let picture = picture_weak.upgrade().unwrap();
-                    let overlay = overlay_weak.upgrade().unwrap();
 
                     let (x, y);
                     let state;
@@ -578,8 +472,7 @@ fn attach_per_display_inputs(
                         return Propagation::Proceed;
                     }
 
-                    let Some((x, y)) = compute_point_inside_paintable(&picture, &overlay, (x, y))
-                    else {
+                    let Some((x, y)) = compute_point_inside_paintable(&picture, (x, y)) else {
                         return Propagation::Proceed;
                     };
 
@@ -595,130 +488,48 @@ fn attach_per_display_inputs(
 
                     Propagation::Stop
                 });
-                overlay.add_controller(input_controller);
+                picture.add_controller(input_controller);
             }
         }
     }
-}
-
-fn build_overlay(window: &Window) -> Overlay {
-    let overlay_bar = HeaderBar::builder()
-        .valign(Align::Start)
-        .hexpand_set(false)
-        .hexpand(false)
-        .opacity(0.8)
-        .build();
-
-    let overlay = Overlay::new();
-    let revealer = Revealer::builder()
-        .transition_type(RevealerTransitionType::SwingDown)
-        .transition_duration(300)
-        .reveal_child(false)
-        .build();
-    revealer.set_child(Some(&overlay_bar));
-    overlay.add_overlay(&revealer);
-
-    let overlay_unfullscreen_btn = Button::builder()
-        .tooltip_text("Exit fullscreen mode")
-        .icon_name("view-restore")
-        .action_name("win.unfullscreen")
-        .build();
-
-    let bar_controller = EventControllerMotion::new();
-    bar_controller.connect_leave(glib::clone!(
-        #[weak]
-        revealer,
-        move |_| {
-            revealer.set_reveal_child(false);
-        }
-    ));
-    overlay_bar.add_controller(bar_controller);
-
-    let overlay_controller = EventControllerMotion::new();
-    overlay_controller.connect_motion(glib::clone!(
-        #[weak]
-        revealer,
-        #[weak]
-        window,
-        move |_motion, _x, y| {
-            if window.is_fullscreen() && y < 1.0 {
-                revealer.set_reveal_child(true);
-            }
-        }
-    ));
-    overlay.add_controller(overlay_controller);
-
-    overlay_bar.pack_end(&overlay_unfullscreen_btn);
-    overlay_bar.set_show_title_buttons(false);
-
-    overlay
 }
 
 pub struct DisplayWorker {
-    app: Application,
-    app_name: String,
     rx: PollableChannelReciever<DisplayEvent>,
-    keyboard_event_tx: Option<EventSender>,
-    per_display_inputs: Vec<Vec<(PollableChannelSender<InputEvent>, DisplayInputOptions)>>,
-    scanouts: RefCell<[Option<ScanoutWindow>; MAX_DISPLAYS]>,
+    paintables: [Option<ScanoutPaintable>; MAX_DISPLAYS],
+    scanouts: RefCell<[Option<ManagedScanout>; MAX_DISPLAYS]>,
 }
 
 impl DisplayWorker {
-    pub fn new(
-        app: Application,
-        app_name: String,
-        rx: PollableChannelReciever<DisplayEvent>,
-        keyboard_event_tx: Option<EventSender>,
-        per_display_inputs: Vec<Vec<(PollableChannelSender<InputEvent>, DisplayInputOptions)>>,
-    ) -> Self {
-        Self {
-            app,
-            app_name,
-            rx,
-            keyboard_event_tx,
-            per_display_inputs,
-            scanouts: Default::default(),
-        }
-    }
-
     fn handle_event(&self) {
         let mut scanouts = self.scanouts.borrow_mut();
         while let Some(msg) = self.rx.try_recv().unwrap() {
             match msg {
                 DisplayEvent::ConfigureScanout {
                     scanout_id,
-                    display_width,
-                    display_height,
                     width,
                     height,
                     format,
+                    ..
                 } => {
-                    if let Some(ref mut scanout) = scanouts[scanout_id as usize] {
+                    let idx = scanout_id as usize;
+                    if let Some(ref mut scanout) = scanouts[idx] {
                         trace!(
                             "Update params of scanout {scanout_id}: width={width} height={height} format={format:?}"
                         );
                         scanout.reconfigure(width as i32, height as i32, format);
-                    } else {
+                    } else if let Some(paintable) = &self.paintables[idx] {
                         debug!(
                             "Enable scanout {scanout_id} width={width} height={height} format={format:?}"
                         );
-                        scanouts[scanout_id as usize] = Some(ScanoutWindow::new(
-                            &self.app,
-                            &format!(
-                                "{name} - display {scanout_id} ({width}x{height})",
-                                name = self.app_name
-                            ),
-                            display_width as i32,
-                            display_height as i32,
-                            width as i32,
-                            height as i32,
+                        scanouts[idx] = Some(ManagedScanout {
+                            paintable: paintable.clone(),
+                            width: width as i32,
+                            height: height as i32,
                             format,
-                            self.keyboard_event_tx.clone(),
-                            self.per_display_inputs
-                                .get(scanout_id as usize)
-                                .cloned()
-                                .unwrap_or_default(),
-                        ));
+                        });
+                    } else {
+                        warn!("No paintable for scanout {scanout_id}");
                     }
                 }
                 DisplayEvent::DisableScanout { scanout_id } => {
@@ -730,7 +541,7 @@ impl DisplayWorker {
                     buffer,
                     rect,
                 } => {
-                    if let Some(scanout) = &mut scanouts[scanout_id as usize] {
+                    if let Some(scanout) = &scanouts[scanout_id as usize] {
                         trace!("Update scanout {scanout_id}");
                         scanout.update(buffer, rect);
                     } else {
@@ -741,13 +552,9 @@ impl DisplayWorker {
         }
     }
 
-    /// Run a GTK application in the current thread handling the krun_gtk_display events send over the channel.
-    /// The events are produces by the `DisplayBackend` which is hooked up into libkrun.
     pub fn run(
-        app_name: String,
-        rx: PollableChannelReciever<DisplayEvent>,
-        keyboard_tx: Option<EventSender>,
-        per_display_inputs: Vec<Vec<(PollableChannelSender<InputEvent>, DisplayInputOptions)>>,
+        worker: crate::DisplayBackendWorker,
+        on_activate: impl FnOnce(&mut crate::DisplayBackendWorker) + 'static,
     ) {
         let app = Application::builder().build();
 
@@ -755,19 +562,29 @@ impl DisplayWorker {
         // app forever, because currently libkrun just exits the process on VM shutdown so there is
         // no way for us to do anything better here for now.
         let _app_hold = app.hold();
-        let rx_fd = rx.as_raw_fd();
+        let rx_fd = worker.display_rx.as_raw_fd();
 
-        let display_worker = Rc::new(DisplayWorker::new(
-            app.clone(),
-            app_name,
-            rx,
-            keyboard_tx,
-            per_display_inputs,
-        ));
+        let worker_cell = Cell::new(Some((worker, on_activate)));
         app.connect_activate(move |_app| {
-            let display_worker = display_worker.clone();
+            let Some((mut worker, on_activate)) = worker_cell.take() else {
+                return;
+            };
+
+            on_activate(&mut worker);
+
+            let mut paintables: [Option<ScanoutPaintable>; MAX_DISPLAYS] = Default::default();
+            for (i, paintable) in worker.paintables.into_iter().enumerate() {
+                paintables[i] = paintable;
+            }
+
+            let display_worker = Rc::new(DisplayWorker {
+                rx: worker.display_rx,
+                paintables,
+                scanouts: RefCell::new(Default::default()),
+            });
+            let display_worker_clone = display_worker.clone();
             unix_fd_add_local(rx_fd, IOCondition::IN, move |_, _| {
-                display_worker.handle_event();
+                display_worker_clone.handle_event();
                 ControlFlow::Continue
             });
         });

--- a/examples/krun_gtk_display/src/lib.rs
+++ b/examples/krun_gtk_display/src/lib.rs
@@ -4,8 +4,9 @@ mod input_backend;
 mod input_constants;
 mod scanout_paintable;
 
-use crate::display_worker::DisplayWorker;
+use crate::display_worker::{DisplayWorker, attach_keyboard, attach_per_display_inputs};
 use crate::input_backend::{GtkInputEventProvider, GtkKeyboardConfig, GtkTouchscreenConfig};
+use crate::scanout_paintable::ScanoutPaintable;
 use anyhow::Context;
 pub use display_backend::DisplayEvent;
 pub use display_backend::GtkDisplayBackend;
@@ -13,6 +14,8 @@ use krun_display::{DisplayBackend, IntoDisplayBackend};
 use krun_input::{InputAbsInfo, InputConfigBackend, InputEventProviderBackend};
 use krun_input::{InputEvent, IntoInputConfig, IntoInputEvents};
 use utils::pollable_channel::{PollableChannelReciever, PollableChannelSender, pollable_channel};
+
+use gtk::{Picture, gdk, prelude::*};
 
 pub struct DisplayBackendHandle {
     tx: PollableChannelSender<DisplayEvent>,
@@ -57,21 +60,42 @@ impl InputBackendHandle {
 }
 
 pub struct DisplayBackendWorker {
-    app_name: String,
-    display_rx: PollableChannelReciever<DisplayEvent>,
-    keyboard_tx: Option<PollableChannelSender<InputEvent>>,
-    per_display_inputs: Vec<Vec<(PollableChannelSender<InputEvent>, DisplayInputOptions)>>,
+    pub(crate) display_rx: PollableChannelReciever<DisplayEvent>,
+    pub(crate) keyboard_tx: Option<PollableChannelSender<InputEvent>>,
+    pub(crate) per_display_inputs:
+        Vec<Vec<(PollableChannelSender<InputEvent>, DisplayInputOptions)>>,
+    pub(crate) paintables: Vec<Option<ScanoutPaintable>>,
 }
 
 impl DisplayBackendWorker {
+    pub fn create_paintable(
+        &mut self,
+        display_id: usize,
+        width: i32,
+        height: i32,
+    ) -> gdk::Paintable {
+        let paintable = ScanoutPaintable::new(width, height);
+        if self.paintables.len() <= display_id {
+            self.paintables.resize_with(display_id + 1, || None);
+        }
+        self.paintables[display_id] = Some(paintable.clone());
+        paintable.upcast()
+    }
+
+    pub fn attach_input(&self, display_id: usize, picture: &Picture) {
+        if let Some(keyboard_tx) = &self.keyboard_tx {
+            picture.set_focusable(true);
+            picture.grab_focus();
+            attach_keyboard(keyboard_tx.clone(), picture);
+        }
+        if let Some(inputs) = self.per_display_inputs.get(display_id) {
+            attach_per_display_inputs(picture, inputs.clone());
+        }
+    }
+
     /// NOTE: on macOS GTK has to run on the main thread of the application.
-    pub fn run(self) {
-        DisplayWorker::run(
-            self.app_name,
-            self.display_rx,
-            self.keyboard_tx,
-            self.per_display_inputs,
-        );
+    pub fn run(self, on_activate: impl FnOnce(&mut Self) + 'static) {
+        DisplayWorker::run(self, on_activate);
     }
 }
 
@@ -125,7 +149,6 @@ pub enum DisplayInputOptions {
 /// `per_display_inputs` is an array indexed by display id.
 /// It contains inputs associated with that specific scanout
 pub fn init(
-    app_name: String,
     keyboard_input: bool,
     per_display_inputs: Vec<Vec<DisplayInputOptions>>,
 ) -> anyhow::Result<(
@@ -172,10 +195,10 @@ pub fn init(
     let display_backend = DisplayBackendHandle { tx: display_tx };
 
     let worker = DisplayBackendWorker {
-        app_name,
         display_rx,
         keyboard_tx,
         per_display_inputs: per_display_event_tx,
+        paintables: Vec::new(),
     };
 
     Ok((display_backend, input_backend_handles, worker))


### PR DESCRIPTION
Currently, the gtk interface does certain things for us like window creations, setting up the header bar and so on... in my use case (running android with libkrun), i don't want any of that, just a window that renders the paintable and input events be handled for me...

In order to achieve that, let the user create the widgets and we just hand them the paintables for them to attach to their window configuration. 

This work similarly to https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/tree/main/video/gtk4?ref_type=heads 

