### PR TITLE
virtio/vsock: clean up UDS socket files on VM exit

### DIFF
--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -15,7 +15,7 @@ use vm_memory::GuestMemoryMmap;
 
 use super::super::{
     ActivateError, ActivateResult, DeviceQueue, DeviceState, Queue as VirtQueue, QueueConfig,
-    VirtioDevice,
+    VirtioDevice, VmmExitObserver,
 };
 use super::TsiFlags;
 use super::muxer::VsockMuxer;
@@ -177,6 +177,12 @@ impl Vsock {
         }
 
         have_used
+    }
+}
+
+impl VmmExitObserver for Vsock {
+    fn on_vmm_exit(&mut self) {
+        self.muxer.cleanup();
     }
 }
 

--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -132,6 +132,16 @@ impl VsockMuxer {
         }
     }
 
+    pub(crate) fn cleanup(&self) {
+        if let Some(ipc_map) = &self.unix_ipc_port_map {
+            for (path, listen) in ipc_map.values() {
+                if *listen {
+                    let _ = std::fs::remove_file(path);
+                }
+            }
+        }
+    }
+
     pub(crate) fn activate(
         &mut self,
         mem: GuestMemoryMmap,

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -2835,6 +2835,8 @@ fn attach_unixsock_vsock_device(
     // The device mutex mustn't be locked here otherwise it will deadlock.
     attach_mmio_device(vmm, id, intc, unix_vsock.clone()).map_err(RegisterVsockDevice)?;
 
+    vmm.exit_observers.push(unix_vsock.clone());
+
     Ok(())
 }
 


### PR DESCRIPTION
Implement VmmExitObserver for the vsock unix muxer so that UDS socket files created for port-to-UDS mappings are removed before the VMM calls _exit(). Without this, stale socket files accumulate across VM runs and can cause bind failures on restart.

The muxer tracks socket paths at bind time and removes them in the exit observer callback. The vsock device is registered as an exit observer during attachment.

Assisted-by: Claude Code: opus-4.6