### PR TITLE
virtio/blk: use the correct new imago API name

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -288,7 +288,7 @@ impl Block {
             .direct(direct_io);
 
         #[cfg(target_os = "macos")]
-        let file_opts = file_opts.relaxed(sync_mode == SyncMode::Relaxed);
+        let file_opts = file_opts.relaxed_sync(sync_mode == SyncMode::Relaxed);
         let file = ImagoFile::open(file_opts)?;
         let discard_alignment = file.discard_align();
 


### PR DESCRIPTION
Commit 8e376d82 upgraded imago to its new fully synchronous API, which renamed `StorageOpenOptions::relaxed` to `relaxed_sync`.

This fixes virtio-blk compilation on macOS.

Assisted-by: OpenCode: gpt-5.6-luna