### PR TITLE
include: fix a "/*" within a comment in libkrun.h

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -602,12 +602,12 @@ int krun_add_input_device(uint32_t ctx_id, const void *config_backend, size_t co
                             const void *events_backend, size_t events_backend_size);
 
 /**
- * Creates a passthrough input device from a host /dev/input/* file descriptor.
+ * Creates a passthrough input device from a host /dev/input/event* file descriptor.
  * The device configuration will be automatically queried from the host device using ioctls.
  * 
  * Arguments:
  *  "ctx_id"  - The krun context
- *  "input_fd" - File descriptor to a /dev/input/* device on the host
+ *  "input_fd" - File descriptor to a /dev/input/event* device on the host
  *
  * Returns:
  *  Zero on success or a negative error code otherwise.


### PR DESCRIPTION
The documentation of `krun_add_input_device_fd()` spells the input device path as `/dev/input/*`, which contains the `/*` sequence:

https://github.com/libkrun/libkrun/blob/6a11683fdb7f10c46180642e03efd805160eb554/include/libkrun.h#L604-L605

so compiler warns when the header is included:

```
libkrun.h:605:61: warning: '/*' within comment [-Wcomment]
libkrun.h:610:49: warning: '/*' within comment [-Wcomment]
```

A project building with `-Werror` cannot include the header at all. In crun this had to be worked around by passing `-Wno-error=comment` for the whole build (containers/crun#2228), which disables the warning for crun's own code as well.

Spell the path as `/dev/input/event*` instead: it does not have the problem, and it is also more accurate, since those are the device nodes the fd is expected to come from.

Verified with `gcc -Wcomment -Werror -fsyntax-only` on a translation unit that includes each header in `include/`: `libkrun.h` fails before this change and all four headers are clean after it.

The same lines are present in `stable-1.19`, so this could use a `cherry-pick-1.19.x` label (I cannot set labels myself).
