### PR TITLE
CI: check that the public headers compile warning free

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -64,6 +64,39 @@ jobs:
         env:
           KRUN_INIT_BINARY_PATH: ${{ github.workspace }}/init/init
 
+  public-headers:
+    name: Public headers
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install compilers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yqq --no-install-recommends gcc g++ clang
+
+      # Every header in include/ is part of the public API, so each one has
+      # to be self contained and warning free on its own: a warning here is
+      # one that every consumer of libkrun gets, and one that a consumer
+      # building with -Werror cannot get rid of at all.
+      - name: Compile every public header on its own
+        run: |
+          status=0
+          for header in include/*.h; do
+              name=$(basename "$header")
+              printf '#include <%s>\n' "$name" > header-check.c
+              cp header-check.c header-check.cc
+              for compiler in "gcc header-check.c" "clang header-check.c" \
+                              "g++ header-check.cc" "clang++ header-check.cc"; do
+                  echo "::group::$name (${compiler%% *})"
+                  # shellcheck disable=SC2086
+                  $compiler -Iinclude -Wall -Wextra -Werror -fsyntax-only || status=1
+                  echo "::endgroup::"
+              done
+          done
+          rm -f header-check.c header-check.cc
+          exit $status
+
   verify-init-blob-bindings:
     name: init-blob bindings
     runs-on: ubuntu-26.04

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -602,12 +602,12 @@ int krun_add_input_device(uint32_t ctx_id, const void *config_backend, size_t co
                             const void *events_backend, size_t events_backend_size);
 
 /**
- * Creates a passthrough input device from a host /dev/input/* file descriptor.
+ * Creates a passthrough input device from a host /dev/input/event* file descriptor.
  * The device configuration will be automatically queried from the host device using ioctls.
  * 
  * Arguments:
  *  "ctx_id"  - The krun context
- *  "input_fd" - File descriptor to a /dev/input/* device on the host
+ *  "input_fd" - File descriptor to a /dev/input/event* device on the host
  *
  * Returns:
  *  Zero on success or a negative error code otherwise.


### PR DESCRIPTION
_Based on (and currently includes) #833, draft until that one is merged._

Every header in `include/` is part of the public API, so a warning in one of them is a warning every consumer of libkrun gets -- and one that a consumer building with `-Werror` cannot get rid of at all: it has to either disable that warning for its own code as well, or stop using `-Werror`. That is exactly what happened with the `/*` in a comment fixed by #833, which crun had to work around with `-Wno-error=comment` for its whole build.

Nothing was watching for that so far, so add a job that compiles each header on its own with `-Wall -Wextra -Werror`, as C and as C++, with both gcc and clang. Compiling each header separately also keeps them self contained: one that only works when included after another would fail here.

Verified locally with the same commands the job runs (gcc, clang, g++, clang++ over all four headers): it passes on this branch, and fails with the expected two errors when `include/libkrun.h` is reverted to its state before #833:

```
include/libkrun.h:605:61: error: '/*' within comment [-Werror=comment]
include/libkrun.h:610:49: error: '/*' within comment [-Werror=comment]
```

Two notes on what the check deliberately does not do:

- It runs without an explicit `-std`. The headers use POSIX types (`uid_t`, `gid_t`), which are not visible in strict ISO C mode (`-std=c11` and friends) unless the consumer defines the feature test macros first, so requiring that here would only be a false alarm.
- It does not use `-Wstrict-prototypes` (not part of `-Wall -Wextra` for gcc). That one currently fires on `krun_create_ctx()` in `libkrun.h` and on two declarations in the generated `libkrun_init.h`, which is why it is left out. If you want those fixed too, the generated header would need a change on the ffier side, so it is better as its own PR.
