### PR TITLE
ci: install git for virglrenderer source build

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -62,6 +62,7 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y \
+          git \
           libepoxy-dev \
           libdrm-dev \
           clang-format \


### PR DESCRIPTION
The setup-build-env action now builds virglrenderer from source, which requires git clone. Some runners don't include git by default.