### PR TITLE
libkrun: add WHP MMIO device manager

### DIFF
--- a/src/libkrun/src/vmm/device_manager/mod.rs
+++ b/src/libkrun/src/vmm/device_manager/mod.rs
@@ -20,3 +20,7 @@ pub use self::kvm::mmio;
 pub mod hvf;
 #[cfg(target_os = "macos")]
 pub use self::hvf::mmio;
+#[cfg(target_os = "windows")]
+pub mod whp;
+#[cfg(target_os = "windows")]
+pub use self::whp::mmio;

--- a/src/libkrun/src/vmm/device_manager/whp/mmio.rs
+++ b/src/libkrun/src/vmm/device_manager/whp/mmio.rs
@@ -1,0 +1,445 @@
+// Copyright 2026 Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! MMIO device manager for the WHP backend.
+//!
+//! Follows the HVF pattern: simpler than the KVM version because there are
+//! no ioeventfd/irqfd mechanisms. Interrupt delivery goes through the
+//! userspace virtio transport layer instead.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::{fmt, io};
+
+use devices::{BusDevice, DeviceType};
+use kernel::cmdline as kernel_cmdline;
+
+/// Errors for MMIO device manager.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to create MmioTransport
+    CreateMmioTransport(devices::virtio::CreateMmioTransportError),
+    /// Failed to perform an operation on the bus.
+    BusError(devices::BusError),
+    /// Appending to kernel command line failed.
+    Cmdline(kernel_cmdline::Error),
+    /// Failure in creating or cloning an event fd.
+    EventFd(io::Error),
+    /// No more IRQs are available.
+    IrqsExhausted,
+    /// Registering an IO Event failed.
+    RegisterIoEvent,
+    /// Registering an IRQ FD failed.
+    RegisterIrqFd,
+    /// The device couldn't be found
+    DeviceNotFound,
+    /// Failed to update the mmio device.
+    UpdateFailed,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::CreateMmioTransport(ref e) => {
+                write!(f, "failed to create mmio transport for the device {e}")
+            }
+            Error::BusError(ref e) => write!(f, "failed to perform bus operation: {e}"),
+            Error::Cmdline(ref e) => {
+                write!(f, "unable to add device to kernel command line: {e}")
+            }
+            Error::EventFd(ref e) => write!(f, "failed to create or clone event descriptor: {e}"),
+            Error::IrqsExhausted => write!(f, "no more IRQs are available"),
+            Error::RegisterIoEvent => write!(f, "failed to register IO event"),
+            Error::RegisterIrqFd => write!(f, "failed to register irqfd"),
+            Error::DeviceNotFound => write!(f, "the device couldn't be found"),
+            Error::UpdateFailed => write!(f, "failed to update the mmio device"),
+        }
+    }
+}
+
+impl From<devices::virtio::CreateMmioTransportError> for Error {
+    fn from(e: devices::virtio::CreateMmioTransportError) -> Self {
+        Self::CreateMmioTransport(e)
+    }
+}
+
+type Result<T> = ::std::result::Result<T, Error>;
+
+/// This represents the size of the mmio device specified to the kernel as a cmdline option
+/// It has to be larger than 0x100 (the offset where the configuration space starts from
+/// the beginning of the memory mapped device registers) + the size of the configuration space
+/// Currently hardcoded to 4K.
+const MMIO_LEN: u64 = 0x1000;
+
+/// Manages the complexities of registering a MMIO device.
+pub struct MMIODeviceManager {
+    pub bus: devices::Bus,
+    mmio_base: u64,
+    irq: u32,
+    last_irq: u32,
+    id_to_dev_info: HashMap<(DeviceType, String), MMIODeviceInfo>,
+}
+
+impl MMIODeviceManager {
+    /// Create a new DeviceManager handling mmio devices (virtio net, block).
+    pub fn new(mmio_base: &mut u64, irq_interval: (u32, u32)) -> MMIODeviceManager {
+        MMIODeviceManager {
+            mmio_base: *mmio_base,
+            irq: irq_interval.0,
+            last_irq: irq_interval.1,
+            bus: devices::Bus::new(),
+            id_to_dev_info: HashMap::new(),
+        }
+    }
+
+    /// Register an already created MMIO device to be used via MMIO transport.
+    pub fn register_mmio_device(
+        &mut self,
+        mut mmio_device: devices::virtio::MmioTransport,
+        type_id: u32,
+        device_id: String,
+    ) -> Result<(u64, u32)> {
+        if self.irq > self.last_irq {
+            return Err(Error::IrqsExhausted);
+        }
+
+        mmio_device.set_irq_line(self.irq);
+
+        self.bus
+            .insert(Arc::new(Mutex::new(mmio_device)), self.mmio_base, MMIO_LEN)
+            .map_err(Error::BusError)?;
+        let ret = (self.mmio_base, self.irq);
+        self.id_to_dev_info.insert(
+            (DeviceType::Virtio(type_id), device_id),
+            MMIODeviceInfo {
+                addr: self.mmio_base,
+                len: MMIO_LEN,
+                irq: self.irq,
+            },
+        );
+        self.mmio_base += MMIO_LEN;
+        self.irq += 1;
+
+        Ok(ret)
+    }
+
+    /// Register an IRQChip device to be used via MMIO transport.
+    pub fn register_mmio_ioapic(
+        &mut self,
+        intc: Option<Arc<Mutex<devices::legacy::IrqChipDevice>>>,
+    ) -> Result<()> {
+        if let Some(intc) = intc {
+            let (mmio_addr, mmio_size) = {
+                let locked = intc.lock().unwrap();
+                (locked.get_mmio_addr(), locked.get_mmio_size())
+            };
+            if mmio_size != 0 {
+                self.bus
+                    .insert(intc, mmio_addr, mmio_size)
+                    .map_err(Error::BusError)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Append a registered MMIO device to the kernel cmdline.
+    pub fn add_device_to_cmdline(
+        &self,
+        cmdline: &mut kernel_cmdline::Cmdline,
+        mmio_base: u64,
+        irq: u32,
+    ) -> Result<()> {
+        // as per doc, [virtio_mmio.]device=<size>@<baseaddr>:<irq> needs to be appended
+        // to kernel commandline for virtio mmio devices to get recognized
+        // the size parameter has to be transformed to KiB, so dividing hexadecimal value in
+        // bytes to 1024; further, the '{}' formatting rust construct will automatically
+        // transform it to decimal
+        cmdline
+            .insert(
+                "virtio_mmio.device",
+                &format!("{}K@0x{:08x}:{}", MMIO_LEN / 1024, mmio_base, irq),
+            )
+            .map_err(Error::Cmdline)
+    }
+
+    /// Gets the specified device.
+    pub fn get_device(
+        &self,
+        device_type: DeviceType,
+        device_id: &str,
+    ) -> Option<&Mutex<dyn BusDevice>> {
+        if let Some(dev_info) = self
+            .id_to_dev_info
+            .get(&(device_type, device_id.to_string()))
+        {
+            if let Some((_, device)) = self.bus.get_device(dev_info.addr) {
+                return Some(device);
+            }
+        }
+        None
+    }
+}
+
+/// Private structure for storing information about the MMIO device registered at some address on the bus.
+#[derive(Clone, Debug)]
+pub struct MMIODeviceInfo {
+    addr: u64,
+    irq: u32,
+    len: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arch;
+    use devices::legacy::DummyIrqChip;
+    use devices::virtio::{
+        ActivateResult, DeviceQueue, InterruptTransport, QueueConfig, VirtioDevice,
+    };
+    use std::sync::Arc;
+    use vm_memory::{GuestAddress, GuestMemoryMmap};
+
+    const QUEUE_SIZES: &[u16] = &[64];
+
+    impl MMIODeviceManager {
+        fn register_virtio_device(
+            &mut self,
+            guest_mem: GuestMemoryMmap,
+            device: Arc<Mutex<dyn devices::virtio::VirtioDevice>>,
+            cmdline: &mut kernel_cmdline::Cmdline,
+            type_id: u32,
+            device_id: &str,
+        ) -> Result<u64> {
+            let mmio_device =
+                devices::virtio::MmioTransport::new(guest_mem, DummyIrqChip::new().into(), device)
+                    .unwrap();
+            let (mmio_base, irq) =
+                self.register_mmio_device(mmio_device, type_id, device_id.to_string())?;
+            self.add_device_to_cmdline(cmdline, mmio_base, irq)?;
+            Ok(mmio_base)
+        }
+    }
+
+    #[allow(dead_code)]
+    struct DummyDevice {
+        dummy: u32,
+        queue_config: Vec<QueueConfig>,
+    }
+
+    impl DummyDevice {
+        pub fn new() -> Self {
+            DummyDevice {
+                dummy: 0,
+                queue_config: QUEUE_SIZES.iter().map(|&s| QueueConfig::new(s)).collect(),
+            }
+        }
+    }
+
+    impl devices::virtio::VirtioDevice for DummyDevice {
+        fn avail_features(&self) -> u64 {
+            0
+        }
+
+        fn acked_features(&self) -> u64 {
+            0
+        }
+
+        fn set_acked_features(&mut self, _: u64) {}
+
+        fn device_type(&self) -> u32 {
+            0
+        }
+
+        fn device_name(&self) -> &str {
+            "dummy"
+        }
+
+        fn queue_config(&self) -> &[QueueConfig] {
+            &self.queue_config
+        }
+
+        fn read_config(&self, offset: u64, data: &mut [u8]) {
+            let _ = offset;
+            let _ = data;
+        }
+
+        fn write_config(&mut self, offset: u64, data: &[u8]) {
+            let _ = offset;
+            let _ = data;
+        }
+
+        fn activate(
+            &mut self,
+            _mem: GuestMemoryMmap,
+            _interrupt: InterruptTransport,
+            _queues: Vec<DeviceQueue>,
+        ) -> ActivateResult {
+            Ok(())
+        }
+
+        fn is_activated(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn test_register_virtio_device() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x1000);
+        let guest_mem =
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let mut device_manager =
+            MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
+
+        let mut cmdline = kernel_cmdline::Cmdline::new(4096);
+        let dummy = Arc::new(Mutex::new(DummyDevice::new()));
+
+        assert!(
+            device_manager
+                .register_virtio_device(guest_mem, dummy, &mut cmdline, 0, "dummy")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_register_too_many_devices() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x1000);
+        let guest_mem =
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let mut device_manager =
+            MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
+
+        let mut cmdline = kernel_cmdline::Cmdline::new(4096);
+
+        for _i in arch::IRQ_BASE..=arch::IRQ_MAX {
+            device_manager
+                .register_virtio_device(
+                    guest_mem.clone(),
+                    Arc::new(Mutex::new(DummyDevice::new())),
+                    &mut cmdline,
+                    0,
+                    "dummy1",
+                )
+                .unwrap();
+        }
+        assert_eq!(
+            format!(
+                "{}",
+                device_manager
+                    .register_virtio_device(
+                        guest_mem,
+                        Arc::new(Mutex::new(DummyDevice::new())),
+                        &mut cmdline,
+                        0,
+                        "dummy2"
+                    )
+                    .unwrap_err()
+            ),
+            "no more IRQs are available".to_string()
+        );
+    }
+
+    #[test]
+    fn test_dummy_device() {
+        let dummy = DummyDevice::new();
+        assert_eq!(dummy.device_type(), 0);
+        assert_eq!(dummy.queue_config().len(), QUEUE_SIZES.len());
+    }
+
+    #[test]
+    fn test_error_messages() {
+        let device_manager =
+            MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
+        let mut cmdline = kernel_cmdline::Cmdline::new(4096);
+        let e = Error::Cmdline(
+            cmdline
+                .insert(
+                    "virtio_mmio=device",
+                    &format!(
+                        "{}K@0x{:08x}:{}",
+                        MMIO_LEN / 1024,
+                        device_manager.mmio_base,
+                        device_manager.irq
+                    ),
+                )
+                .unwrap_err(),
+        );
+        assert_eq!(
+            format!("{e}"),
+            format!(
+                "unable to add device to kernel command line: {}",
+                kernel_cmdline::Error::HasEquals
+            ),
+        );
+        assert_eq!(
+            format!("{}", Error::UpdateFailed),
+            "failed to update the mmio device"
+        );
+        assert_eq!(
+            format!("{}", Error::BusError(devices::BusError::Overlap)),
+            format!(
+                "failed to perform bus operation: {}",
+                devices::BusError::Overlap
+            )
+        );
+        assert_eq!(
+            format!("{}", Error::IrqsExhausted),
+            "no more IRQs are available"
+        );
+        assert_eq!(
+            format!("{}", Error::RegisterIoEvent),
+            "failed to register IO event"
+        );
+        assert_eq!(
+            format!("{}", Error::RegisterIrqFd),
+            "failed to register irqfd"
+        );
+    }
+
+    #[test]
+    fn test_device_info() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x1000);
+        let guest_mem =
+            GuestMemoryMmap::from_ranges(&[(start_addr1, 0x1000), (start_addr2, 0x1000)]).unwrap();
+        let mut device_manager =
+            MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
+        let mut cmdline = kernel_cmdline::Cmdline::new(4096);
+        let dummy = Arc::new(Mutex::new(DummyDevice::new()));
+
+        let type_id = 0;
+        let id = String::from("foo");
+        if let Ok(addr) =
+            device_manager.register_virtio_device(guest_mem, dummy, &mut cmdline, type_id, &id)
+        {
+            assert!(
+                device_manager
+                    .get_device(DeviceType::Virtio(type_id), &id)
+                    .is_some()
+            );
+            assert_eq!(
+                addr,
+                device_manager.id_to_dev_info[&(DeviceType::Virtio(type_id), id.clone())].addr
+            );
+            assert_eq!(
+                arch::IRQ_BASE,
+                device_manager.id_to_dev_info[&(DeviceType::Virtio(type_id), id.clone())].irq
+            );
+        }
+        let id = "bar";
+        assert!(
+            device_manager
+                .get_device(DeviceType::Virtio(type_id), id)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_register_ioapic_none() {
+        let mut device_manager =
+            MMIODeviceManager::new(&mut 0xd000_0000, (arch::IRQ_BASE, arch::IRQ_MAX));
+        assert!(device_manager.register_mmio_ioapic(None).is_ok());
+    }
+}

--- a/src/libkrun/src/vmm/device_manager/whp/mod.rs
+++ b/src/libkrun/src/vmm/device_manager/whp/mod.rs
@@ -1,0 +1,1 @@
+pub mod mmio;


### PR DESCRIPTION
Add a device_manager/whp/ module following the HVF pattern: simpler than the KVM version because there are no ioeventfd/irqfd mechanisms. MMIO device registration, address allocation, and interrupt routing are handled entirely in userspace.