### PR TITLE
libkrun: implement an API to set render server fd

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -644,6 +644,20 @@ int32_t krun_set_gpu_options2(uint32_t ctx_id,
                               uint32_t virgl_flags,
                               uint64_t shm_size);
 
+/**
+ * Sets the file descriptor of the virgl render server to be used instead of having
+ * libvirglrenderer starting it on its own. This enables the caller to have total control
+ * over the context where the render server is started.
+ *
+ * Arguments:
+ *  "ctx_id"            - the configuration context ID.
+ *  "render_server_fd"  - the file descriptor of the render server.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_gpu_render_server_fd(uint32_t ctx_id, int render_server_fd);
+
 /* Maximum number of displays. Same as VIRTIO_GPU_MAX_SCANOUTS defined in the virtio-gpu spec */
 #define KRUN_MAX_DISPLAYS 16
 

--- a/src/devices/src/virtio/gpu/device.rs
+++ b/src/devices/src/virtio/gpu/device.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::os::fd::RawFd;
 
 #[cfg(target_os = "macos")]
 use crossbeam_channel::Sender;
@@ -36,6 +37,7 @@ pub struct Gpu {
     pub(crate) device_state: DeviceState,
     shm_region: Option<VirtioShmRegion>,
     virgl_flags: u32,
+    render_server_fd: Option<RawFd>,
     #[cfg(target_os = "macos")]
     map_sender: Sender<WorkerMessage>,
     export_table: Option<ExportTable>,
@@ -46,6 +48,7 @@ pub struct Gpu {
 impl Gpu {
     pub fn new(
         virgl_flags: u32,
+        render_server_fd: Option<RawFd>,
         displays: Box<[DisplayInfo]>,
         display_backend: DisplayBackend<'static>,
         #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
@@ -56,6 +59,7 @@ impl Gpu {
             device_state: DeviceState::Inactive,
             shm_region: None,
             virgl_flags,
+            render_server_fd,
             #[cfg(target_os = "macos")]
             map_sender,
             export_table: None,
@@ -213,6 +217,7 @@ impl VirtioDevice for Gpu {
             interrupt.clone(),
             shm_region,
             self.virgl_flags,
+            self.render_server_fd,
             #[cfg(target_os = "macos")]
             self.map_sender.clone(),
             self.export_table.take(),

--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::io::IoSliceMut;
 #[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
+use std::os::fd::RawFd;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -31,6 +32,7 @@ use rutabaga_gfx::{
     RutabagaFence, RutabagaFenceHandler, RutabagaIovec, Transfer3D, RUTABAGA_CHANNEL_TYPE_WAYLAND,
     RUTABAGA_MAP_CACHE_MASK,
 };
+use rutabaga_gfx::{RutabagaDescriptor, RutabagaFromRawDescriptor};
 #[cfg(target_os = "linux")]
 use rutabaga_gfx::{
     RUTABAGA_CHANNEL_TYPE_PW, RUTABAGA_CHANNEL_TYPE_X11, RUTABAGA_MAP_ACCESS_MASK,
@@ -221,6 +223,7 @@ impl VirtioGpu {
         interrupt: InterruptTransport,
         fence_state: Arc<Mutex<FenceState>>,
         virgl_flags: u32,
+        render_server_fd: Option<RawFd>,
         export_table: Option<ExportTable>,
     ) -> Option<Rutabaga> {
         let xdg_runtime_dir = match env::var("XDG_RUNTIME_DIR") {
@@ -278,7 +281,13 @@ impl VirtioGpu {
 
         let fence =
             Self::create_fence_handler(mem, queue_ctl.clone(), fence_state.clone(), interrupt);
-        builder.clone().build(fence.clone(), None).ok()
+        builder
+            .clone()
+            .build(
+                fence.clone(),
+                render_server_fd.map(|fd| unsafe { RutabagaDescriptor::from_raw_descriptor(fd) }),
+            )
+            .ok()
     }
 
     pub fn create_fallback_rutabaga(
@@ -305,6 +314,7 @@ impl VirtioGpu {
         queue_ctl: Arc<Mutex<VirtQueue>>,
         interrupt: InterruptTransport,
         virgl_flags: u32,
+        render_server_fd: Option<RawFd>,
         #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
         export_table: Option<ExportTable>,
         displays: Box<[DisplayInfo]>,
@@ -318,6 +328,7 @@ impl VirtioGpu {
             interrupt.clone(),
             fence_state.clone(),
             virgl_flags,
+            render_server_fd,
             export_table.clone(),
         ) {
             Some(rutabaga) => rutabaga,

--- a/src/devices/src/virtio/gpu/worker.rs
+++ b/src/devices/src/virtio/gpu/worker.rs
@@ -1,5 +1,5 @@
 use std::io::Read;
-use std::os::fd::{AsRawFd, BorrowedFd};
+use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -37,6 +37,7 @@ pub struct Worker {
     interrupt: InterruptTransport,
     shm_region: VirtioShmRegion,
     virgl_flags: u32,
+    render_server_fd: Option<RawFd>,
     #[cfg(target_os = "macos")]
     map_sender: Sender<WorkerMessage>,
     export_table: Option<ExportTable>,
@@ -52,6 +53,7 @@ impl Worker {
         interrupt: InterruptTransport,
         shm_region: VirtioShmRegion,
         virgl_flags: u32,
+        render_server_fd: Option<RawFd>,
         #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
         export_table: Option<ExportTable>,
         displays: Box<[DisplayInfo]>,
@@ -72,6 +74,7 @@ impl Worker {
             interrupt,
             shm_region,
             virgl_flags,
+            render_server_fd,
             #[cfg(target_os = "macos")]
             map_sender,
             export_table,
@@ -93,6 +96,7 @@ impl Worker {
             self.control_queue.clone(),
             self.interrupt.clone(),
             self.virgl_flags,
+            self.render_server_fd,
             #[cfg(target_os = "macos")]
             self.map_sender.clone(),
             self.export_table.take(),

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -184,6 +184,7 @@ struct ContextConfig {
     shutdown_efd: Option<EventFd>,
     gpu_virgl_flags: Option<u32>,
     gpu_shm_size: Option<usize>,
+    render_server_fd: Option<RawFd>,
     enable_snd: bool,
     console_output: Option<PathBuf>,
     vmm_uid: Option<libc::uid_t>,
@@ -1572,6 +1573,24 @@ pub unsafe extern "C" fn krun_set_gpu_options2(
             let cfg = ctx_cfg.get_mut();
             cfg.set_gpu_virgl_flags(virgl_flags);
             cfg.set_gpu_shm_size(shm_size.try_into().unwrap());
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn krun_set_gpu_render_server_fd(ctx_id: u32, render_server_fd: i32) -> i32 {
+    if render_server_fd < 0 {
+        return -libc::EINVAL;
+    }
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            let cfg = ctx_cfg.get_mut();
+            cfg.render_server_fd = Some(render_server_fd);
         }
         Entry::Vacant(_) => return -libc::ENOENT,
     }
@@ -2981,6 +3000,9 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
     }
     if let Some(shm_size) = ctx_cfg.gpu_shm_size {
         ctx_cfg.vmr.set_gpu_shm_size(shm_size);
+    }
+    if let Some(render_server_fd) = ctx_cfg.render_server_fd {
+        ctx_cfg.vmr.set_gpu_render_server_fd(render_server_fd);
     }
 
     #[cfg(feature = "snd")]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -12,8 +12,9 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::fs::File;
 use std::io::{self, IsTerminal, Read};
-use std::os::fd::AsRawFd;
-use std::os::fd::{BorrowedFd, FromRawFd};
+#[cfg(feature = "gpu")]
+use std::os::fd::RawFd;
+use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicI32;
 use std::sync::{Arc, Mutex};
@@ -1019,6 +1020,7 @@ pub fn build_microvm(
             export_table.clone(),
             intc.clone(),
             virgl_flags,
+            vm_resources.gpu_render_server_fd,
             Box::from(&vm_resources.displays[..]),
             display_backend,
             #[cfg(target_os = "macos")]
@@ -2264,6 +2266,7 @@ fn attach_gpu_device(
     #[cfg(not(feature = "tee"))] mut export_table: Option<ExportTable>,
     intc: IrqChip,
     virgl_flags: u32,
+    render_server_fd: Option<RawFd>,
     displays: Box<[DisplayInfo]>,
     display_backend: DisplayBackend<'static>,
     #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
@@ -2273,6 +2276,7 @@ fn attach_gpu_device(
     let gpu = Arc::new(Mutex::new(
         devices::virtio::Gpu::new(
             virgl_flags,
+            render_server_fd,
             displays,
             display_backend,
             #[cfg(target_os = "macos")]

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -161,6 +161,7 @@ pub struct VmResources {
     /// Flags for the virtio-gpu device.
     pub gpu_virgl_flags: Option<u32>,
     pub gpu_shm_size: Option<usize>,
+    pub gpu_render_server_fd: Option<RawFd>,
     #[cfg(feature = "gpu")]
     pub display_backend: Option<DisplayBackend<'static>>,
     #[cfg(feature = "gpu")]
@@ -342,6 +343,10 @@ impl VmResources {
         self.gpu_shm_size = Some(shm_size);
     }
 
+    pub fn set_gpu_render_server_fd(&mut self, gpu_render_server_fd: RawFd) {
+        self.gpu_render_server_fd = Some(gpu_render_server_fd);
+    }
+
     #[cfg(feature = "snd")]
     pub fn set_snd_device(&mut self, enabled: bool) {
         self.snd_device = enabled;
@@ -421,6 +426,7 @@ mod tests {
             net: Default::default(),
             gpu_virgl_flags: None,
             gpu_shm_size: None,
+            gpu_render_server_fd: None,
             #[cfg(feature = "gpu")]
             display_backend: None,
             #[cfg(feature = "gpu")]


### PR DESCRIPTION
Implement an API that allows users passing to us a render server fd to
be used instead of having libvirglrenderer starting it on its own.

This provides users total control over the context where the render
server is started.
