### PR TITLE
virtio/gpu: Allow enabling gfxstream feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ endif
 ifeq ($(GPU),1)
     FEATURE_FLAGS += --features gpu
 endif
+ifeq ($(GFXSTREAM),1)
+    FEATURE_FLAGS += --features gfxstream
+endif
 ifeq ($(INPUT),1)
     FEATURE_FLAGS += --features input
 endif

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -15,6 +15,7 @@ tdx = ["blk", "tee"]
 net = []
 blk = []
 gpu = ["rutabaga_gfx", "thiserror", "zerocopy", "krun_display"]
+gfxstream = ["rutabaga_gfx/gfxstream"]
 input = ["zerocopy", "krun_input"]
 virgl_resource_map2 = []
 aws-nitro = []
@@ -52,7 +53,6 @@ hvf = { package = "krun-hvf", version = "=0.1.0-2.0.0-dev", path = "../hvf" }
 lru = ">=0.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rutabaga_gfx = { version = "0.1.85", features = ["virgl_renderer"], optional = true }
 caps = "0.5.5"
 kvm-bindings = { version = "0.14.1", features = ["fam-wrappers"] }
 kvm-ioctls = "0.25"

--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -1156,5 +1156,11 @@ pub fn virgl_flags_to_capsets(flags: u32) -> u64 {
         capset_mask |= 1 << rutabaga_gfx::RUTABAGA_CAPSET_DRM;
     }
 
+    if flags & VIRGLRENDERER_NO_VIRGL != 0 {
+        capset_mask |= 1 << rutabaga_gfx::RUTABAGA_CAPSET_GFXSTREAM_VULKAN;
+        capset_mask |= 1 << rutabaga_gfx::RUTABAGA_CAPSET_GFXSTREAM_GLES;
+        capset_mask |= 1 << rutabaga_gfx::RUTABAGA_CAPSET_GFXSTREAM_COMPOSER;
+    }
+
     capset_mask
 }

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -15,6 +15,7 @@ tdx = ["blk", "tee", "kbs-types", "serde", "serde_json", "dep:tdx", "devices/tdx
 net = ["devices/net"]
 blk = ["devices/blk"]
 gpu = ["devices/gpu", "krun_display"]
+gfxstream = ["devices/gfxstream"]
 input = ["krun_input", "devices/input"]
 virgl_resource_map2 = ["devices/virgl_resource_map2"]
 aws-nitro = ["devices/aws-nitro", "dep:aws-nitro", "dep:nitro-enclaves"]


### PR DESCRIPTION
Needed for using that with Android as a rendering backend instead of virgl.

Tested with Android 17.