### PR TITLE
virtio/fs/macos: handle absent capability xattrs correctly

### DIFF
--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -1251,8 +1251,8 @@ fn remove_security_capability(file: &InodeHandle) {
         },
     };
 
-    // ENODATA means the attribute didn't exist, which is fine
-    if ret != 0 && io::Error::last_os_error().raw_os_error() != Some(libc::ENODATA) {
+    // ENOATTR means the attribute didn't exist, which is fine
+    if ret != 0 && io::Error::last_os_error().raw_os_error() != Some(libc::ENOATTR) {
         warn!("Error removing security.capability from file");
     }
 }


### PR DESCRIPTION
## Summary

Replace `ENODATA` with macOS's `ENOATTR` in the capability-removal check and its comment. An absent attribute no longer produces a false warning. This is the entire diff requested in review.

## Testing

The local real-syscall regression fails with the old constant and passes with this change, including existing-attribute removal and genuine-error controls. The regression is kept outside the commit. All 56 existing device tests with `net,blk`, formatting, and default Clippy with `-D warnings` pass.

## Reviewer Focus

Please backport to `stable-1.19` (`cherry-pick-1.19.5`). DCO sign-off and AI attribution are included.
