### PR TITLE
vmm: aarch64: expose SVE to the guest when the host supports it

### DIFF
--- a/src/libkrun/src/vmm/linux/vstate.rs
+++ b/src/libkrun/src/vmm/linux/vstate.rs
@@ -147,6 +147,9 @@ pub enum Error {
     /// Error doing Vcpu Init on Arm.
     VcpuArmInit(kvm_ioctls::Error),
     #[cfg(target_arch = "aarch64")]
+    /// Error finalizing a Vcpu feature on Arm.
+    VcpuArmFinalize(kvm_ioctls::Error),
+    #[cfg(target_arch = "aarch64")]
     /// Error getting the Vcpu preferred target on Arm.
     VcpuArmPreferredTarget(kvm_ioctls::Error),
     /// Cannot open the VCPU file descriptor.
@@ -390,6 +393,10 @@ impl Display for Error {
             }
             #[cfg(target_arch = "aarch64")]
             VcpuArmInit(e) => write!(f, "Error doing Vcpu Init on Arm: {e}"),
+            #[cfg(target_arch = "aarch64")]
+            VcpuArmFinalize(e) => {
+                write!(f, "Error finalizing a Vcpu feature on Arm: {e}")
+            }
 
             #[cfg(feature = "tee")]
             InvalidTee => write!(f, "TEE selected is not currently supported"),
@@ -1254,7 +1261,21 @@ impl Vcpu {
             kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PTRAUTH_GENERIC;
         }
 
+        // Expose SVE to the guest when the host can virtualise it.
+        let sve = vm_fd.check_extension(kvm_ioctls::Cap::ArmSve);
+        if sve {
+            kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_SVE;
+        }
+
         self.fd.vcpu_init(&kvi).map_err(Error::VcpuArmInit)?;
+
+        // Must precede any register access; KVM returns -EPERM until finalized.
+        if sve {
+            self.fd
+                .vcpu_finalize(&(kvm_bindings::KVM_ARM_VCPU_SVE as std::os::raw::c_int))
+                .map_err(Error::VcpuArmFinalize)?;
+        }
+
         arch::aarch64::regs::setup_regs(&self.fd, self.id, kernel_load_addr.raw_value(), mem_info)
             .map_err(Error::REGSConfiguration)?;
 


### PR DESCRIPTION
## Summary

`configure_aarch64()` requested PSCI, power-off and both pointer-authentication
features, but never `KVM_ARM_VCPU_SVE`. KVM gates SVE explicitly, so the guest read
`ID_AA64PFR0_EL1.SVE` as 0 and any SVE instruction executed in the guest trapped as
undefined.

That is fatal once userspace is built for an ARMv9 core: GCC autovectorises with SVE,
so ordinary binaries carry SVE in their instruction stream. On an MT8196
(Cortex-A720/X4/X925) host with userspace built for `cortex-a720`, `python3` inside
the microVM died with `SIGILL` — `libgallium` alone carries over 14000 SVE
instructions.

This is #845 retargeted at `main`, as requested. The diff is identical; only the file
path differs, since `src/vmm/src/` moved to `src/libkrun/src/vmm/`.

## Changes

- Request `KVM_ARM_VCPU_SVE` in `configure_aarch64()` when the host advertises
  `KVM_CAP_ARM_SVE`.
- Finalize the feature immediately after `vcpu_init()`, before `setup_regs()` and
  `read_mpidr()`. `kvm_arm_vcpu_is_finalized()` makes `KVM_{GET,SET}_ONE_REG` return
  `-EPERM` until finalization completes, so the ordering is load-bearing.
- Add an `Error::VcpuArmFinalize` variant and its `Display` arm.

21 insertions in `src/libkrun/src/vmm/linux/vstate.rs`, no dependency changes —
`Cap::ArmSve`, `vcpu_finalize()` and `KVM_ARM_VCPU_SVE` are all already available in
the pinned kvm-ioctls 0.25.0 / kvm-bindings 0.14.1.

## Testing

The runtime testing was done on the `stable-1.19.x` branch (#845), where this change
is byte-identical modulo the file move. Verified on MT8196 rauru-navi
(Cortex-A720 ×4 / X4 ×3 / X925), host kernel 7.2.2, guest kernel 6.12.44 from
libkrunfw:

| | guest SVE hwcaps | `python3 -c 'print(sum(range(100000)))'` |
|---|---|---|
| before | *(none)* | `Illegal instruction`, exit 132 |
| after | `sve sve2 sveaes svepmull svebitperm svesha3 svesm4 svei8mm svebf16` | `4999950000`, exit 0 |

Confirmed against the library installed from the built image, not a staged copy.

I have not re-run that test against `main` — I don't currently have a muvm build
tracking `main` on that hardware. 

## Notes for Reviewers

- **No vector-length register is set.** `KVM_REG_ARM64_SVE_VLS` is left alone, so KVM
  defaults the vCPU to the host's maximum virtualisable length. Keeps the change
  minimal; a VMM that wants to pin a VL would set it between `vcpu_init()` and
  finalization.
- **Capability-gated**, so this is a no-op on hosts without `KVM_CAP_ARM_SVE` and
  cannot regress older hardware.
- **No other ARMv9 feature needs this.** Only features carrying extra CPU state to
  context-switch are opt-in in KVM — SVE, and pointer auth which was already
  requested. Everything else reaches the guest through the sanitised ID registers.
  Verified rather than assumed: with this patch the guest and host `/proc/cpuinfo`
  `Features` lines are byte-identical, so `i8mm`, `bf16`, `fcma`, `frint`, `jscvt`,
  `flagm2`, `uscat`, `ilrcpc`, `dcpodp`, `ecv`, `afp`, `wfxt`, `dgh`, `bti`, `sb` and
  `dit` were all already present.